### PR TITLE
(v2) Step1: 이벤트 위임을 고려해 DOM 조작 및 이벤트 리스너 등록

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 					<div class="wrapper bg-white p-10">
 						<div class="heading d-flex justify-between">
 							<h2 class="mt-1">☕ 에스프레소 메뉴 관리</h2>
-							<span class="mr-2 mt-4 menu-count">총 0개</span>
+							<span class="mr-2 mt-4" id="menu-count">총 0개</span>
 						</div>
 						<form id="espresso-menu-form">
 							<div class="d-flex w-100">

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 					<div class="wrapper bg-white p-10">
 						<div class="heading d-flex justify-between">
 							<h2 class="mt-1">☕ 에스프레소 메뉴 관리</h2>
-							<span class="mr-2 mt-4" id="menu-count">총 0개</span>
+							<span class="mr-2 mt-4 menu-count">총 0개</span>
 						</div>
 						<form id="espresso-menu-form">
 							<div class="d-flex w-100">

--- a/index.html
+++ b/index.html
@@ -1,89 +1,67 @@
 <!DOCTYPE html>
 <html lang="kr">
+
 <head>
-  <meta charset="UTF-8" />
-  <title>문벅스 메뉴</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="shortcut icon" href="src/images/favicon.ico" />
-  <link rel="icon" href="src/images/favicon.png" />
-  <link rel="stylesheet" href="src/css/index.css" />
+	<meta charset="UTF-8" />
+	<title>문벅스 메뉴</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="shortcut icon" href="src/images/favicon.ico" />
+	<link rel="icon" href="src/images/favicon.png" />
+	<link rel="stylesheet" href="src/css/index.css" />
 </head>
+
 <body>
-<div id="app" class="px-4">
-  <div class="d-flex justify-center mt-5 w-100">
-    <div class="w-100">
-      <header class="my-4">
-        <a href="/" class="text-black">
-          <h1 class="text-center font-bold">🌝 문벅스 메뉴 관리</h1>
-        </a>
-        <nav class="d-flex justify-center flex-wrap">
-          <button
-                  data-category-name="espresso"
-                  class="cafe-category-name btn bg-white shadow mx-1"
-          >
-            ☕ 에스프레소
-          </button>
-          <button
-                  data-category-name="frappuccino"
-                  class="cafe-category-name btn bg-white shadow mx-1"
-          >
-            🥤 프라푸치노
-          </button>
-          <button
-                  data-category-name="blended"
-                  class="cafe-category-name btn bg-white shadow mx-1"
-          >
-            🍹 블렌디드
-          </button>
-          <button
-                  data-category-name="teavana"
-                  class="cafe-category-name btn bg-white shadow mx-1"
-          >
-            🫖 티바나
-          </button>
-          <button
-                  data-category-name="desert"
-                  class="cafe-category-name btn bg-white shadow mx-1"
-          >
-            🍰 디저트
-          </button>
-        </nav>
-      </header>
-      <main class="mt-10 d-flex justify-center">
-        <div class="wrapper bg-white p-10">
-          <div class="heading d-flex justify-between">
-            <h2 class="mt-1">☕ 에스프레소 메뉴 관리</h2>
-            <span class="mr-2 mt-4 menu-count">총 0개</span>
-          </div>
-          <form id="espresso-menu-form">
-            <div class="d-flex w-100">
-              <label for="espresso-menu-name" class="input-label" hidden>
-                에스프레소 메뉴 이름
-              </label>
-              <input
-                      type="text"
-                      id="espresso-menu-name"
-                      name="espressoMenuName"
-                      class="input-field"
-                      placeholder="에스프레소 메뉴 이름"
-                      autocomplete="off"
-              />
-              <button
-                      type="button"
-                      name="submit"
-                      id="espresso-menu-submit-button"
-                      class="input-submit bg-green-600 ml-2"
-              >
-                확인
-              </button>
-            </div>
-          </form>
-          <ul id="espresso-menu-list" class="mt-3 pl-0"></ul>
-        </div>
-      </main>
-    </div>
-  </div>
-</div>
-<script type="module" src="./src/js/index.js"></script>
+	<div id="app" class="px-4">
+		<div class="d-flex justify-center mt-5 w-100">
+			<div class="w-100">
+				<header class="my-4">
+					<a href="/" class="text-black">
+						<h1 class="text-center font-bold">🌝 문벅스 메뉴 관리</h1>
+					</a>
+					<nav class="d-flex justify-center flex-wrap">
+						<button data-category-name="espresso" class="cafe-category-name btn bg-white shadow mx-1">
+							☕ 에스프레소
+						</button>
+						<button data-category-name="frappuccino" class="cafe-category-name btn bg-white shadow mx-1">
+							🥤 프라푸치노
+						</button>
+						<button data-category-name="blended" class="cafe-category-name btn bg-white shadow mx-1">
+							🍹 블렌디드
+						</button>
+						<button data-category-name="teavana" class="cafe-category-name btn bg-white shadow mx-1">
+							🫖 티바나
+						</button>
+						<button data-category-name="desert" class="cafe-category-name btn bg-white shadow mx-1">
+							🍰 디저트
+						</button>
+					</nav>
+				</header>
+				<main class="mt-10 d-flex justify-center">
+					<div class="wrapper bg-white p-10">
+						<div class="heading d-flex justify-between">
+							<h2 class="mt-1">☕ 에스프레소 메뉴 관리</h2>
+							<span class="mr-2 mt-4 menu-count">총 0개</span>
+						</div>
+						<form id="espresso-menu-form">
+							<div class="d-flex w-100">
+								<label for="espresso-menu-name" class="input-label" hidden>
+									에스프레소 메뉴 이름
+								</label>
+								<input type="text" id="espresso-menu-name" name="espressoMenuName" class="input-field"
+									placeholder="에스프레소 메뉴 이름" autocomplete="off" />
+								<button type="submit" name="submit" id="espresso-menu-submit-button"
+									class="input-submit bg-green-600 ml-2">
+									확인
+								</button>
+							</div>
+						</form>
+						<ul id="espresso-menu-list" class="mt-3 pl-0"></ul>
+					</div>
+				</main>
+			</div>
+		</div>
+	</div>
+	<script type="module" src="./src/js/index.js"></script>
 </body>
+
 </html>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,13 +1,15 @@
 // Step1: 돔 조작과 이벤트 핸들링으로 메뉴 관리하기
 
-const form = document.querySelector("#espresso-menu-form")
-const input = document.querySelector("#espresso-menu-name")
-const button = document.querySelector("#espresso-menu-submit-button")
-const list = document.querySelector("#espresso-menu-list")
-const cnt = document.querySelector(".menu-count")
+const $ = (selector) => document.querySelector(selector)
+const form = $("#espresso-menu-form")
+const input = $("#espresso-menu-name")
+const list = $("#espresso-menu-list")
+const cnt = $(".menu-count")
 
-// TODO 1. 메뉴 추가
-// - [v] form 요소의 submit 이벤트로 addMenu 이벤트 핸들러 바인딩
+function updateTotal() {
+  const num = list.querySelectorAll("li").length
+  cnt.innerText = `총 ${num}개`
+}
 
 const createHTML = (name) => `
 				<span class="w-100 pl-2 menu-name">${name}</span>
@@ -40,14 +42,6 @@ function addMenu() {
   input.value = ""
 }
 
-function updateTotal() {
-  const num = list.querySelectorAll("li").length
-  cnt.innerText = `총 ${num}개`
-}
-
-// TODO 2. 메뉴 수정/삭제
-// - [v] createElem 함수를 data-* 속성을 적용한 html 템플릿으로 대체.
-// - [v] 메뉴 수정과 삭제 이벤트 처리를 <ul> 요소에 위임.
 function updateMenu(e) {
   const span = e.target.closest("li").querySelector("span")
   const ret = prompt("메뉴명을 수정하세요", span.innerHTML)
@@ -64,11 +58,13 @@ function removeMenu(e) {
 }
 
 function App() {
+  //  form 요소의 상위 submit 이벤트로 하위 요소의 click, keyup 이벤트 처리
   form.addEventListener("submit", (e) => {
     e.preventDefault()
     addMenu()
   })
 
+  // ul 요소에 수정/삭제 button 이벤트 위임
   list.addEventListener("click", (e) => {
     if (e.target.classList.contains("data-edit")) {
       updateMenu(e)

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -8,11 +8,7 @@ const cnt = document.querySelector(".menu-count")
 let nums = 0
 
 // TODO 1. 메뉴 추가
-// - [v] 메뉴 이름을 입력받고 확인 버튼을 누르면 메뉴를 추가한다.
-// - [v] 메뉴 이름을 입력받고 엔터키 입력으로 메뉴를 추가한다.
-// - [v] 메뉴가 추가되고 나면, input은 빈 값으로 초기화한다.
-// - [v] 사용자 입력값이 빈 값이라면 추가되지 않는다.
-// - [v] 추가되는 메뉴의 아래 마크업은 <ul id ="espresso-menu-list" class="mt-3 pl-0" ></ul> 안에 삽입해야 한다.
+// - [] form 요소의 submit 이벤트로 addMenu 이벤트 핸들러 바인딩
 
 function createElem(item, name) {
   const span = document.createElement("span")
@@ -40,8 +36,6 @@ function createElem(item, name) {
   item.appendChild(remove)
 }
 
-// TODO 4. 기타
-// - [v] 총 메뉴 갯수를 count하여 상단에 보여준다.
 function updateTotal() {
   cnt.innerHTML = `총 ${nums}개`
 }
@@ -63,18 +57,15 @@ function addMenu() {
   input.value = ""
 }
 
-// TODO 2. 메뉴 수정
-// - [v] 메뉴의 수정 버튼 클릭 이벤트가 발생하면, 브라우저 prompt 인터페이스가 뜬다.
-// - [v] 메뉴 수정 시 prompt 인터페이스에 수정 메뉴명을 기입하고 확인 버튼을 누르면 메뉴 이름이 업데이트된다.
+// TODO 2. 메뉴 수정/삭제
+// - [ ] createElem 함수를 data-* 속성을 적용한 html 템플릿으로 대체.
+// - [ ] 메뉴 수정과 삭제 이벤트 처리를 <ul> 요소에 위임.
 function updateMenu(span) {
   const ret = prompt("메뉴명을 수정하세요", span.innerHTML)
   if (ret === null) return
   span.innerHTML = ret
 }
 
-// TODO 3. 메뉴 삭제
-// - [v] 메뉴의 삭제 버튼을 누르면 브라우저 confirm 인터페이스가 뜬다.
-// - [v] 메뉴 삭제 시 confirm 인터페이스에 확인 버튼을 누르면 메뉴가 삭제된다.
 function removeMenu(item) {
   const ret = confirm("정말 삭제하시겠습니까?")
   if (!ret) return

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -10,35 +10,25 @@ let nums = 0
 // TODO 1. 메뉴 추가
 // - [v] form 요소의 submit 이벤트로 addMenu 이벤트 핸들러 바인딩
 
-function createElem(item, name) {
-  const span = document.createElement("span")
-  span.className = "w-100 pl-2 menu-name"
-  span.innerHTML = name
-
-  const edit = document.createElement("button")
-  edit.type = "button"
-  edit.className = "bg-gray-50 text-gray-500 text-sm mr-1 menu-edit-button"
-  edit.innerHTML = "수정"
-  edit.addEventListener("click", () => {
-    updateMenu(span)
-  })
-
-  const remove = document.createElement("button")
-  remove.type = "button"
-  remove.className = "bg-gray-50 text-gray-500 text-sm menu-remove-button"
-  remove.innerHTML = "삭제"
-  remove.addEventListener("click", () => {
-    removeMenu(item)
-  })
-
-  item.appendChild(span)
-  item.appendChild(edit)
-  item.appendChild(remove)
-}
-
 function updateTotal() {
   cnt.innerHTML = `총 ${nums}개`
 }
+
+const createHTML = (name) => `
+				<span class="w-100 pl-2 menu-name">${name}</span>
+				<button
+					type="button"
+					class="bg-gray-50 text-gray-500 text-sm mr-1 menu-edit-button data-edit"
+				>
+					수정
+				</button>
+				<button
+					type="button"
+					class="bg-gray-50 text-gray-500 text-sm menu-remove-button data-remove"
+				>
+					삭제
+				</button>
+			`
 
 function addMenu() {
   const name = input.value
@@ -46,8 +36,7 @@ function addMenu() {
 
   const item = document.createElement("li")
   item.className = "menu-list-item d-flex items-center py-2"
-
-  createElem(item, name)
+  item.innerHTML = createHTML(name)
 
   list.appendChild(item)
 
@@ -58,7 +47,7 @@ function addMenu() {
 }
 
 // TODO 2. 메뉴 수정/삭제
-// - [ ] createElem 함수를 data-* 속성을 적용한 html 템플릿으로 대체.
+// - [v] createElem 함수를 data-* 속성을 적용한 html 템플릿으로 대체.
 // - [ ] 메뉴 수정과 삭제 이벤트 처리를 <ul> 요소에 위임.
 function updateMenu(span) {
   const ret = prompt("메뉴명을 수정하세요", span.innerHTML)

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -5,14 +5,9 @@ const input = document.querySelector("#espresso-menu-name")
 const button = document.querySelector("#espresso-menu-submit-button")
 const list = document.querySelector("#espresso-menu-list")
 const cnt = document.querySelector(".menu-count")
-let nums = 0
 
 // TODO 1. 메뉴 추가
 // - [v] form 요소의 submit 이벤트로 addMenu 이벤트 핸들러 바인딩
-
-function updateTotal() {
-  cnt.innerHTML = `총 ${nums}개`
-}
 
 const createHTML = (name) => `
 				<span class="w-100 pl-2 menu-name">${name}</span>
@@ -40,26 +35,31 @@ function addMenu() {
 
   list.appendChild(item)
 
-  nums += 1
   updateTotal()
 
   input.value = ""
 }
 
+function updateTotal() {
+  const num = list.querySelectorAll("li").length
+  cnt.innerText = `총 ${num}개`
+}
+
 // TODO 2. 메뉴 수정/삭제
 // - [v] createElem 함수를 data-* 속성을 적용한 html 템플릿으로 대체.
-// - [ ] 메뉴 수정과 삭제 이벤트 처리를 <ul> 요소에 위임.
-function updateMenu(span) {
+// - [v] 메뉴 수정과 삭제 이벤트 처리를 <ul> 요소에 위임.
+function updateMenu(e) {
+  const span = e.target.closest("li").querySelector("span")
   const ret = prompt("메뉴명을 수정하세요", span.innerHTML)
   if (ret === null) return
   span.innerHTML = ret
 }
 
-function removeMenu(item) {
+function removeMenu(e) {
+  const li = e.target.closest("li")
   const ret = confirm("정말 삭제하시겠습니까?")
   if (!ret) return
-  list.removeChild(item)
-  nums -= 1
+  li.remove()
   updateTotal()
 }
 
@@ -68,14 +68,15 @@ function App() {
     e.preventDefault()
     addMenu()
   })
-  // button.addEventListener("click", () => {
-  //   addMenu()
-  // })
-  // input.addEventListener("keyup", (e) => {
-  //   if (e.key === "Enter") {
-  //     addMenu()
-  //   }
-  // })
+
+  list.addEventListener("click", (e) => {
+    if (e.target.classList.contains("data-edit")) {
+      updateMenu(e)
+    }
+    if (e.target.classList.contains("data-remove")) {
+      removeMenu(e)
+    }
+  })
 }
 
 App()

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,10 +1,10 @@
 // Step1: 돔 조작과 이벤트 핸들링으로 메뉴 관리하기
 
-const $ = (selector) => document.querySelector(selector)
-const form = $("#espresso-menu-form")
-const input = $("#espresso-menu-name")
-const list = $("#espresso-menu-list")
-const cnt = $(".menu-count")
+const $ = (id) => document.getElementById(id)
+const form = $("espresso-menu-form")
+const input = $("espresso-menu-name")
+const list = $("espresso-menu-list")
+const cnt = $("menu-count")
 
 function updateTotal() {
   const num = list.querySelectorAll("li").length

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,10 +1,11 @@
 // Step1: 돔 조작과 이벤트 핸들링으로 메뉴 관리하기
 
-const $ = (id) => document.getElementById(id)
-const form = $("espresso-menu-form")
-const input = $("espresso-menu-name")
-const list = $("espresso-menu-list")
-const cnt = $("menu-count")
+const $ = (selector) => document.querySelector(selector)
+
+const form = $("#espresso-menu-form")
+const input = $("#espresso-menu-name")
+const list = $("#espresso-menu-list")
+const cnt = $(".menu-count")
 
 function updateTotal() {
   const num = list.querySelectorAll("li").length

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -8,7 +8,7 @@ const cnt = document.querySelector(".menu-count")
 let nums = 0
 
 // TODO 1. 메뉴 추가
-// - [] form 요소의 submit 이벤트로 addMenu 이벤트 핸들러 바인딩
+// - [v] form 요소의 submit 이벤트로 addMenu 이벤트 핸들러 바인딩
 
 function createElem(item, name) {
   const span = document.createElement("span")
@@ -77,15 +77,16 @@ function removeMenu(item) {
 function App() {
   form.addEventListener("submit", (e) => {
     e.preventDefault()
-  })
-  button.addEventListener("click", () => {
     addMenu()
   })
-  input.addEventListener("keyup", (e) => {
-    if (e.key === "Enter") {
-      addMenu()
-    }
-  })
+  // button.addEventListener("click", () => {
+  //   addMenu()
+  // })
+  // input.addEventListener("keyup", (e) => {
+  //   if (e.key === "Enter") {
+  //     addMenu()
+  //   }
+  // })
 }
 
 App()


### PR DESCRIPTION
# 🎯 이벤트 위임을 고려하여 step1 코드 리팩토링
> 이벤트 버블링/캡쳐링/위임에 대해 생각하며 코드를 리팩토링했습니다. 
## 핵심 변경 사항 🔧
✅ form 요소의 상위 submit 이벤트로 하위 요소의 click, keyup 이벤트 처리
✅ 상위 ul 요소에 하위 수정/삭제 button 요소의 이벤트 위임

# ✨ 상세 설명
## 이벤트 위임 적용한 코드 리팩토링 🔧
### ☕ 1. 메뉴 추가: 선행 이벤트와 후행 이벤트의 관계를 고려한 코드 간소화

- 메뉴 추가 시 사용자가 발생시키는 이벤트는 *<input>* `keyup`과 *<button>* `click` 이고, `keyup` 은 event.key == Enter 일 때만 동작함.
- index.html에서 `<form>` 태그 하위에 `<input>` , `<button type=’button’>` 태그가 있음. `<button>`의 type을 submit으로 바꿔주면, `<input> keyup`  event.key == Enter와 `<button> click` 과 일 때의 이벤트는 모두 `<form>` 태그의 `submit` 이벤트로 이어짐.
       <details> <summary> 변경 코드 </summary>
     ```html
      <form id="espresso-menu-form">
        <div class="d-flex w-100">
          <label for="espresso-menu-name" class="input-label" hidden>
            에스프레소 메뉴 이름
          </label>
          <input
                  type="text"
                  id="espresso-menu-name"
                  name="espressoMenuName"
                  class="input-field"
                  placeholder="에스프레소 메뉴 이름"
                  autocomplete="off"
          />
          <button
                  type="submit"
                  name="submit"
                  id="espresso-menu-submit-button"
                  class="input-submit bg-green-600 ml-2"
          >
            확인
          </button>
        </div>
      </form>
     ```     
     </details>
- 즉, 사용자의 선행 이벤트 `click`, `keyup` 에 굳이 따로 이벤트 핸들러를 바인딩 할 필요 없이, <form> 요소의 `submit` 이벤트의 기본 브라우저 동작을 막고, 메뉴 추가 이벤트 리스너를 달아주는 식으로 코드 간소화 가능.
  ```javascript
  function App() {
    //  form 요소의 상위 submit 이벤트로 하위 요소의 click, keyup 이벤트 처리
    form.addEventListener("submit", (e) => {
      e.preventDefault()
      addMenu()
    })
   }
  ```

### ☕ 2. 메뉴 수정/삭제: 이벤트 위임과 data-* 속성을 활용한 코드 간소화
    
- 현재 코드는 동적으로 DOM 요소가 생성될 때마다 이벤트가 실제로 발생하는 버튼 각각에 `updateMenu`, `removeMenu` 이벤트 핸들러를 바인딩해줌.
- 이렇게 이벤트 발생 대상 각각에 이벤트 리스너를 등록하는 경우, 코드가 복잡해지고 메모리 낭비로 인한 성능 저하 이슈가 발생함.
- 수정과 삭제 버튼 각각이 아니라 모든 목록 공통 부모 요소인 `<ul>`에 수정과 삭제를 위한 이벤트 처리를 위임함으로서 이를 해결할 수 있음.
- 기존 코드에서는 신규 메뉴가추가될 때마다 `createElem` 함수를 호출했으나 이를 `data-*` 속성과 이벤트 위임을 통해 간단한 html 템플릿을 `innerHTML` 속성을 부여해 추가하는 방식으로 코드 간략화.
    ```javascript
      const createHTML = (name) => `
		<span class="w-100 pl-2 menu-name">${name}</span>
		<button
			type="button"
			class="bg-gray-50 text-gray-500 text-sm mr-1 menu-edit-button data-edit">
			수정
		</button>
		<button
			type="button"
			class="bg-gray-50 text-gray-500 text-sm menu-remove-button data-remove"
		>
			삭제
		</button>`
    ```


- 수정과 삭제 버튼 각각에 `data-edit, data-remove` 라는 사용자 정의 데이터 속성을 부여한 뒤, 조상 요소의 이벤트 위임 과정에서 `classList.contains()` 함수를 통해 해당 데이터 속성을 포함하고 있는지를 확인하여 수정과 삭제에 적절한 이벤트 핸들러를 호출해줄 수 있음.
  ```javascript
  // ul 요소에 수정/삭제 button 이벤트 위임
    list.addEventListener("click", (e) => {
      if (e.target.classList.contains("data-edit")) {
        updateMenu(e)
      }
      if (e.target.classList.contains("data-remove")) {
        removeMenu(e)
      }
    })
  ```

### ~~☕ 3. 총 메뉴 개수 카운트: 최상위요소 document에 이벤트 위임하여 코드 간소화 → 시도하지 말자.~~
    
- 그냥 단순히 메뉴 카운트 함수 `updateTotal()`을 메뉴 추가 함수 `addMenu()`와 삭제 함수 `removeMenu()` 하단에 추가해주는 것이 가장 간단한 로직임.
- 하지만 만약 한군데에서 관리하고 싶다면, 이벤트 위임으로 두 이벤트 모두를 처리하기 위해서는 최소한 `<main>` 요소에 작성해야함. 하지만 이 경우, `<main>` 요소 내의 모든 `click` 이벤트가 발생할 때마다 불필요하게 `updateTotal()` 함수가 호출됨. ~~(이를 방지하려면 click 이벤트에 대한 분기처리 코드가 필요하나 이렇게 작성하는 것이 더 복잡하다고 판단됨.)~~
