### PR TITLE
(v3)Step1: DOM 요소 조정 과정 추상화한 React 환경 모방

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 <br/>
 <p align="middle">
   <img width="200px;" src="./src/images/moonbucks.png"/>
@@ -244,3 +245,6 @@ live-server 폴더명
 ## 📝 License
 
 This project is [MIT](https://github.com/blackcoffee-study/moonbucks-menu/blob/main/LICENSE) licensed.
+=======
+# StateManagement
+>>>>>>> Initial commit

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -36,6 +36,7 @@ let state = {
 
 let renderTimes = 0
 
+// render 내에서 동작하는 addMenu 이벤트
 const addMenu = () => {
   const { menu } = state
   const input = $("input")
@@ -68,11 +69,16 @@ function updateMenu(e) {
 }
 
 function removeMenu(e) {
-  const li = e.target.closest("li")
+  const { menu } = state
+
   const ret = confirm("정말 삭제하시겠습니까?")
   if (!ret) return
-  li.remove()
-  updateTotal()
+
+  const index = Number(e.target.dataset.index)
+
+  setState({
+    menu: menu.filter((_, idx) => index !== idx),
+  })
 }
 
 const render = () => {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -32,6 +32,19 @@ let state = {
   ],
 }
 
+const addMenu = () => {
+  const { menu } = state
+  const input = $("input")
+
+  const name = input.value
+
+  if (!name) return
+
+  setState({ menu: [...menu, name] })
+
+  input.value = ""
+}
+
 const render = () => {
   const { menu } = state
   list.innerHTML = `
@@ -42,9 +55,7 @@ const render = () => {
   // 메뉴 추가
   $("form").addEventListener("submit", (e) => {
     e.preventDefault()
-    const name = $("input").value
-    if (!name) return
-    setState({ menu: [...menu, name] })
+    addMenu()
   })
 }
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -39,6 +39,7 @@ const render = () => {
 			${menu.map((name) => createItem(name)).join("")}
 		</ul>
 	`
+  // 메뉴 추가
   $("form").addEventListener("submit", (e) => {
     e.preventDefault()
     const name = $("input").value
@@ -67,21 +68,6 @@ render()
 // function updateTotal() {
 //   const num = list.querySelectorAll("li").length
 //   cnt.innerText = `총 ${num}개`
-// }
-
-// function addMenu() {
-//   const name = input.value
-//   if (!name) return
-
-//   const item = document.createElement("li")
-//   item.className = "menu-list-item d-flex items-center py-2"
-//   item.innerHTML = createHTML(name)
-
-//   list.appendChild(item)
-
-//   updateTotal()
-
-//   input.value = ""
 // }
 
 // function updateMenu(e) {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -103,7 +103,7 @@ const render = () => {
 		</ul>
 	`
 
-  // TODO: [Issue: 메뉴 추가/ 수정/ 삭제시마다 동일한 이벤트 핸들러가 추가됨]
+  // TODO: [Issue: 메뉴 추가/ 수정/ 삭제시마다 동일한 이벤트 핸들러가 추가됨]!!
   console.log(`[Issue] Same Event Handler Enrolled ${renderTimes} times`)
 
   // 메뉴 추가

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -36,7 +36,6 @@ let state = {
 
 let renderTimes = 0
 
-// render 내에서 동작하는 addMenu 이벤트
 const addMenu = () => {
   const { menu } = state
   const input = $("input")
@@ -60,6 +59,7 @@ function updateMenu(e) {
 
   if (newName === null) return
 
+  // setState 통해 메뉴 업데이트 시 자동으로 DOM 요소 처리함
   setState({
     menu: menu.map((name, idx) => {
       if (index === idx) return newName
@@ -76,12 +76,20 @@ function removeMenu(e) {
 
   const index = Number(e.target.dataset.index)
 
+  // setState 통해 메뉴 삭제 시 자동으로 DOM 요소 처리함
   setState({
     menu: menu.filter((_, idx) => index !== idx),
   })
 }
 
+function updateTotal() {
+  const { menu } = state
+  const cnt = $(".menu-count")
+  cnt.innerText = `총 ${menu.length}개`
+}
+
 const render = () => {
+  console.log("[Render] Called!")
   renderTimes += 1
 
   const { menu } = state
@@ -94,6 +102,10 @@ const render = () => {
 			${menu.map((name, idx) => createItem(name, idx)).join("")}
 		</ul>
 	`
+
+  // TODO: [Issue: 메뉴 추가/ 수정/ 삭제시마다 동일한 이벤트 핸들러가 추가됨]
+  console.log(`[Issue] Same Event Handler Enrolled ${renderTimes} times`)
+
   // 메뉴 추가
   form.addEventListener("submit", (e) => {
     e.preventDefault()
@@ -109,6 +121,8 @@ const render = () => {
       removeMenu(e)
     }
   })
+
+  updateTotal()
 }
 
 const setState = (newState) => {
@@ -123,30 +137,3 @@ const setState = (newState) => {
 }
 
 render()
-
-// const cnt = $(".menu-count")
-
-// function updateTotal() {
-//   const num = list.querySelectorAll("li").length
-//   cnt.innerText = `총 ${num}개`
-// }
-
-// function App() {
-//   //  form 요소의 상위 submit 이벤트로 하위 요소의 click, keyup 이벤트 처리
-//   form.addEventListener("submit", (e) => {
-//     e.preventDefault()
-//     addMenu()
-//   })
-
-//   // ul 요소에 수정/삭제 button 이벤트 위임
-//   list.addEventListener("click", (e) => {
-//     if (e.target.classList.contains("data-edit")) {
-//       updateMenu(e)
-//     }
-//     if (e.target.classList.contains("data-remove")) {
-//       removeMenu(e)
-//     }
-//   })
-// }
-
-// App()

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,17 +1,19 @@
 // Step1: 돔 조작과 이벤트 핸들링으로 메뉴 관리하기(v3)
 
-const createItem = (name) => `
+const createItem = (name, key) => `
 			<li class="menu-list-item d-flex items-center py-2">
 				<span class="w-100 pl-2 menu-name">${name}</span>
 				<button
 					type="button"
 					class="bg-gray-50 text-gray-500 text-sm mr-1 menu-edit-button data-edit"
+					data-index=${key}
 				>
 					수정
 				</button>
 				<button
 					type="button"
 					class="bg-gray-50 text-gray-500 text-sm menu-remove-button data-remove"
+					data-index=${key}
 				>
 					삭제
 				</button>
@@ -32,6 +34,8 @@ let state = {
   ],
 }
 
+let renderTimes = 0
+
 const addMenu = () => {
   const { menu } = state
   const input = $("input")
@@ -40,22 +44,64 @@ const addMenu = () => {
 
   if (!name) return
 
-  setState({ menu: [...menu, name] })
+  setState({ menu: [...menu, name] }) // setState 통해 메뉴 추가시 자동으로 DOM 요소 처리함
 
   input.value = ""
 }
 
-const render = () => {
+function updateMenu(e) {
   const { menu } = state
+
+  const prevName = e.target.closest("li").querySelector("span").innerText
+  const index = Number(e.target.dataset.index)
+
+  const newName = prompt("메뉴명을 수정하세요", prevName)
+
+  if (newName === null) return
+
+  setState({
+    menu: menu.map((name, idx) => {
+      if (index === idx) return newName
+      return name
+    }),
+  })
+}
+
+function removeMenu(e) {
+  const li = e.target.closest("li")
+  const ret = confirm("정말 삭제하시겠습니까?")
+  if (!ret) return
+  li.remove()
+  updateTotal()
+}
+
+const render = () => {
+  renderTimes += 1
+
+  const { menu } = state
+
+  const form = $("form")
+  const list = $("ul")
+
   list.innerHTML = `
 		<ul id="espresso-menu-list" class="mt-3 pl-0">
-			${menu.map((name) => createItem(name)).join("")}
+			${menu.map((name, idx) => createItem(name, idx)).join("")}
 		</ul>
 	`
   // 메뉴 추가
-  $("form").addEventListener("submit", (e) => {
+  form.addEventListener("submit", (e) => {
     e.preventDefault()
     addMenu()
+  })
+
+  // 메뉴 수정/삭제
+  list.addEventListener("click", (e) => {
+    if (e.target.classList.contains("data-edit")) {
+      updateMenu(e)
+    }
+    if (e.target.classList.contains("data-remove")) {
+      removeMenu(e)
+    }
   })
 }
 
@@ -72,28 +118,11 @@ const setState = (newState) => {
 
 render()
 
-// const form = $("#espresso-menu-form")
-// const input = $("#espresso-menu-name")
 // const cnt = $(".menu-count")
 
 // function updateTotal() {
 //   const num = list.querySelectorAll("li").length
 //   cnt.innerText = `총 ${num}개`
-// }
-
-// function updateMenu(e) {
-//   const span = e.target.closest("li").querySelector("span")
-//   const ret = prompt("메뉴명을 수정하세요", span.innerHTML)
-//   if (ret === null) return
-//   span.innerHTML = ret
-// }
-
-// function removeMenu(e) {
-//   const li = e.target.closest("li")
-//   const ret = confirm("정말 삭제하시겠습니까?")
-//   if (!ret) return
-//   li.remove()
-//   updateTotal()
 // }
 
 // function App() {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,18 +1,7 @@
-// Step1: 돔 조작과 이벤트 핸들링으로 메뉴 관리하기
+// Step1: 돔 조작과 이벤트 핸들링으로 메뉴 관리하기(v3)
 
-const $ = (selector) => document.querySelector(selector)
-
-const form = $("#espresso-menu-form")
-const input = $("#espresso-menu-name")
-const list = $("#espresso-menu-list")
-const cnt = $(".menu-count")
-
-function updateTotal() {
-  const num = list.querySelectorAll("li").length
-  cnt.innerText = `총 ${num}개`
-}
-
-const createHTML = (name) => `
+const createItem = (name) => `
+			<li class="menu-list-item d-flex items-center py-2">
 				<span class="w-100 pl-2 menu-name">${name}</span>
 				<button
 					type="button"
@@ -26,54 +15,106 @@ const createHTML = (name) => `
 				>
 					삭제
 				</button>
+			</li>
 			`
 
-function addMenu() {
-  const name = input.value
-  if (!name) return
+const $ = (selector) => document.querySelector(selector)
+const list = $("#espresso-menu-list")
 
-  const item = document.createElement("li")
-  item.className = "menu-list-item d-flex items-center py-2"
-  item.innerHTML = createHTML(name)
-
-  list.appendChild(item)
-
-  updateTotal()
-
-  input.value = ""
+let state = {
+  menu: [
+    "long black",
+    "americano",
+    "espresso con panna",
+    "lattte",
+    "cafe mocha",
+    "cappucino",
+  ],
 }
 
-function updateMenu(e) {
-  const span = e.target.closest("li").querySelector("span")
-  const ret = prompt("메뉴명을 수정하세요", span.innerHTML)
-  if (ret === null) return
-  span.innerHTML = ret
-}
-
-function removeMenu(e) {
-  const li = e.target.closest("li")
-  const ret = confirm("정말 삭제하시겠습니까?")
-  if (!ret) return
-  li.remove()
-  updateTotal()
-}
-
-function App() {
-  //  form 요소의 상위 submit 이벤트로 하위 요소의 click, keyup 이벤트 처리
-  form.addEventListener("submit", (e) => {
+const render = () => {
+  const { menu } = state
+  list.innerHTML = `
+		<ul id="espresso-menu-list" class="mt-3 pl-0">
+			${menu.map((name) => createItem(name)).join("")}
+		</ul>
+	`
+  $("form").addEventListener("submit", (e) => {
     e.preventDefault()
-    addMenu()
-  })
-
-  // ul 요소에 수정/삭제 button 이벤트 위임
-  list.addEventListener("click", (e) => {
-    if (e.target.classList.contains("data-edit")) {
-      updateMenu(e)
-    }
-    if (e.target.classList.contains("data-remove")) {
-      removeMenu(e)
-    }
+    const name = $("input").value
+    if (!name) return
+    setState({ menu: [...menu, name] })
   })
 }
 
-App()
+const setState = (newState) => {
+  const prevState = state
+  state = { ...state, ...newState }
+  console.log(
+    `[setState]: \n(prevState) ${JSON.stringify(
+      prevState
+    )} \n(currState) ${JSON.stringify(state)}`
+  )
+  render()
+}
+
+render()
+
+// const form = $("#espresso-menu-form")
+// const input = $("#espresso-menu-name")
+// const cnt = $(".menu-count")
+
+// function updateTotal() {
+//   const num = list.querySelectorAll("li").length
+//   cnt.innerText = `총 ${num}개`
+// }
+
+// function addMenu() {
+//   const name = input.value
+//   if (!name) return
+
+//   const item = document.createElement("li")
+//   item.className = "menu-list-item d-flex items-center py-2"
+//   item.innerHTML = createHTML(name)
+
+//   list.appendChild(item)
+
+//   updateTotal()
+
+//   input.value = ""
+// }
+
+// function updateMenu(e) {
+//   const span = e.target.closest("li").querySelector("span")
+//   const ret = prompt("메뉴명을 수정하세요", span.innerHTML)
+//   if (ret === null) return
+//   span.innerHTML = ret
+// }
+
+// function removeMenu(e) {
+//   const li = e.target.closest("li")
+//   const ret = confirm("정말 삭제하시겠습니까?")
+//   if (!ret) return
+//   li.remove()
+//   updateTotal()
+// }
+
+// function App() {
+//   //  form 요소의 상위 submit 이벤트로 하위 요소의 click, keyup 이벤트 처리
+//   form.addEventListener("submit", (e) => {
+//     e.preventDefault()
+//     addMenu()
+//   })
+
+//   // ul 요소에 수정/삭제 button 이벤트 위임
+//   list.addEventListener("click", (e) => {
+//     if (e.target.classList.contains("data-edit")) {
+//       updateMenu(e)
+//     }
+//     if (e.target.classList.contains("data-remove")) {
+//       removeMenu(e)
+//     }
+//   })
+// }
+
+// App()

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -23,8 +23,50 @@ const createItem = (name, key) => `
 const $ = (selector) => document.querySelector(selector)
 
 /*
- * state: 컴포넌트 내부에서 관리할 상태값
+ * Component: state, setState, render 및 기타 메서드로 구성된 웹 컴포넌트
  **/
+class Component {
+  $target
+  $state
+
+  constructor($target, $state) {
+    this.$target = $target
+    this.setup()
+    this.render()
+  }
+
+  // setup: 초기 state 설정하는 함수
+  setup() {}
+
+  // template: target DOM 요소 내부의 자식 요소들을 문자열 형태로 반환하는 함수
+  template() {
+    return ""
+  }
+
+  // setEvent: target DOM 요소에 이벤트 핸들러를 등록하는 함수
+  setEvent() {}
+
+  // render: 맨 처음이나 컴포넌트 상태 변화시 DOM 요소 조정 과정을 추상화한 함수
+  render() {
+    this.$target.innerHTML = this.template()
+    this.setEvent()
+  }
+
+  // setState: 컴포넌트 내부 상태 업데이트 하는 과정을 추상화한 함수
+  setState(newState) {
+    this.$state = { ...this.$state, ...newState }
+    console.log(
+      `[setState]: \n(prevState) ${JSON.stringify(
+        prevState
+      )} \n(currState) ${JSON.stringify(state)}`
+    )
+    this.render()
+  }
+}
+
+/*
+ * state: 상태
+ */
 let state = {
   menu: [
     "long black",
@@ -37,12 +79,43 @@ let state = {
 }
 
 /*
+ * setEventHandler: DOM 요소에 이벤트 핸들러 등록
+ **/
+const setEventHandler = () => {
+  const form = $("form")
+  const list = $("ul")
+
+  // 메뉴 추가
+  form.addEventListener("submit", (e) => {
+    e.preventDefault()
+    addMenu()
+  })
+
+  // 메뉴 수정/삭제
+  list.addEventListener("click", (e) => {
+    if (e.target.classList.contains("data-edit")) {
+      updateMenu(e)
+    }
+    if (e.target.classList.contains("data-remove")) {
+      removeMenu(e)
+    }
+  })
+}
+
+/*
+ * initialRender : 최초 렌더링 시에만 setEventHandler 수행해 이벤트 핸들러 등록
+ **/
+const initialRender = () => {
+  setEventHandler()
+  render()
+}
+
+/*
  * render: 맨 처음이나 컴포넌트 상태 변화시 DOM 요소 조정 과정을 추상화한 함수
  **/
 const render = () => {
   const { menu } = state
 
-  const form = $("form")
   const list = $("ul")
 
   list.innerHTML = `
@@ -50,11 +123,6 @@ const render = () => {
 			${menu.map((name, idx) => createItem(name, idx)).join("")}
 		</ul>
 	`
-  // 메뉴 추가
-  form.addEventListener("submit", addEventHandler)
-
-  // 메뉴 수정/삭제
-  list.addEventListener("click", updateRemoveEventHandler)
 
   updateTotal()
 }
@@ -73,7 +141,7 @@ const setState = (newState) => {
   render()
 }
 
-render()
+initialRender()
 
 /*
  * 하단의 addMenu, updateMenu, removeMenu, updateTotal은 render 함수 내부에서 호출하는 함수
@@ -129,23 +197,4 @@ function updateTotal() {
   const { menu } = state
   const cnt = $(".menu-count")
   cnt.innerText = `총 ${menu.length}개`
-}
-
-/*
- * 동일 이벤트에 대해 동일한 이벤트를 여러 번 등록하지 않도록 하기 위해, 별도의 함수로 분리.
- * addEventListener는 이벤트 핸들러를 큐에 넣기 전, 참조 메모리 주소에 의해 동일성 여부 검사함.
- **/
-
-function addEventHandler(e) {
-  e.preventDefault()
-  addMenu()
-}
-
-function updateRemoveEventHandler(e) {
-  if (e.target.classList.contains("data-edit")) {
-    updateMenu(e)
-  }
-  if (e.target.classList.contains("data-remove")) {
-    removeMenu(e)
-  }
 }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -21,8 +21,10 @@ const createItem = (name, key) => `
 			`
 
 const $ = (selector) => document.querySelector(selector)
-const list = $("#espresso-menu-list")
 
+/*
+ * state: 컴포넌트 내부에서 관리할 상태값
+ **/
 let state = {
   menu: [
     "long black",
@@ -34,8 +36,49 @@ let state = {
   ],
 }
 
-let renderTimes = 0
+/*
+ * render: 맨 처음이나 컴포넌트 상태 변화시 DOM 요소 조정 과정을 추상화한 함수
+ **/
+const render = () => {
+  const { menu } = state
 
+  const form = $("form")
+  const list = $("ul")
+
+  list.innerHTML = `
+		<ul id="espresso-menu-list" class="mt-3 pl-0">
+			${menu.map((name, idx) => createItem(name, idx)).join("")}
+		</ul>
+	`
+  // 메뉴 추가
+  form.addEventListener("submit", addEventHandler)
+
+  // 메뉴 수정/삭제
+  list.addEventListener("click", updateRemoveEventHandler)
+
+  updateTotal()
+}
+
+/*
+ * setState: 컴포넌트 내부 상태 업데이트 하는 과정을 추상화한 함수
+ **/
+const setState = (newState) => {
+  const prevState = state
+  state = { ...state, ...newState }
+  console.log(
+    `[setState]: \n(prevState) ${JSON.stringify(
+      prevState
+    )} \n(currState) ${JSON.stringify(state)}`
+  )
+  render()
+}
+
+render()
+
+/*
+ * 하단의 addMenu, updateMenu, removeMenu, updateTotal은 render 함수 내부에서 호출하는 함수
+ * DOM 요소에는 값을 가져올 때만 접근하고, 값이 변경될 때 DOM 요소를 직접 접근하지 않고 setState로 처리함
+ **/
 const addMenu = () => {
   const { menu } = state
   const input = $("input")
@@ -88,6 +131,11 @@ function updateTotal() {
   cnt.innerText = `총 ${menu.length}개`
 }
 
+/*
+ * 동일 이벤트에 대해 동일한 이벤트를 여러 번 등록하지 않도록 하기 위해, 별도의 함수로 분리.
+ * addEventListener는 이벤트 핸들러를 큐에 넣기 전, 참조 메모리 주소에 의해 동일성 여부 검사함.
+ **/
+
 function addEventHandler(e) {
   e.preventDefault()
   addMenu()
@@ -101,39 +149,3 @@ function updateRemoveEventHandler(e) {
     removeMenu(e)
   }
 }
-
-const render = () => {
-  console.log("[Render] Called!")
-  renderTimes += 1
-
-  const { menu } = state
-
-  const form = $("form")
-  const list = $("ul")
-
-  list.innerHTML = `
-		<ul id="espresso-menu-list" class="mt-3 pl-0">
-			${menu.map((name, idx) => createItem(name, idx)).join("")}
-		</ul>
-	`
-  // 메뉴 추가
-  form.addEventListener("submit", addEventHandler)
-
-  // 메뉴 수정/삭제
-  list.addEventListener("click", updateRemoveEventHandler)
-
-  updateTotal()
-}
-
-const setState = (newState) => {
-  const prevState = state
-  state = { ...state, ...newState }
-  console.log(
-    `[setState]: \n(prevState) ${JSON.stringify(
-      prevState
-    )} \n(currState) ${JSON.stringify(state)}`
-  )
-  render()
-}
-
-render()

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -88,6 +88,20 @@ function updateTotal() {
   cnt.innerText = `총 ${menu.length}개`
 }
 
+function addEventHandler(e) {
+  e.preventDefault()
+  addMenu()
+}
+
+function updateRemoveEventHandler(e) {
+  if (e.target.classList.contains("data-edit")) {
+    updateMenu(e)
+  }
+  if (e.target.classList.contains("data-remove")) {
+    removeMenu(e)
+  }
+}
+
 const render = () => {
   console.log("[Render] Called!")
   renderTimes += 1
@@ -102,25 +116,11 @@ const render = () => {
 			${menu.map((name, idx) => createItem(name, idx)).join("")}
 		</ul>
 	`
-
-  // TODO: [Issue: 메뉴 추가/ 수정/ 삭제시마다 동일한 이벤트 핸들러가 추가됨]!!
-  console.log(`[Issue] Same Event Handler Enrolled ${renderTimes} times`)
-
   // 메뉴 추가
-  form.addEventListener("submit", (e) => {
-    e.preventDefault()
-    addMenu()
-  })
+  form.addEventListener("submit", addEventHandler)
 
   // 메뉴 수정/삭제
-  list.addEventListener("click", (e) => {
-    if (e.target.classList.contains("data-edit")) {
-      updateMenu(e)
-    }
-    if (e.target.classList.contains("data-remove")) {
-      removeMenu(e)
-    }
-  })
+  list.addEventListener("click", updateRemoveEventHandler)
 
   updateTotal()
 }


### PR DESCRIPTION
# 👨‍💻 v2 -> v3 리팩토링

## 🗒️  핵심 변화 
✅ (1) 인자로 받은 값으로 기존 상태를 업데이트 시키는 코드 setStaet 함수로 추상화
✅  (2) 상태 변화에 맞게 사용자에게 보여질 DOM 요소 조정 코드 render 함수로 추상화
✅  이벤트 등록 함수 render 외부로 분리해 중복 등록 이슈 해결

## ✨ 리팩토링 배경
> 💡 v2 → v3로의 리팩토링에서는 상태 변화 시 `(1) 기존 상태값을 업데이트 하는 과정을 setState 함수`로 
> `(2) 상태 변화에 맞게 사용자에게 보여질 DOM 요소를 조정하는 과정을 render 함수`로 추상화하여, 
> **React에서 setState만 호출하면 자동 리렌더링이 발생하는 환경**을 모방해보고자 함.

### 😅 v2: DOM 요소에 직접 상태를 저장하는 방식(jQuery)의 코드

- step1 v2 코드는 전통적인 jQuery 방식으로 구현되어 있음. 즉, `DOM 요소를 불러와서 DOM 요소의 data-* 속성을 통해 DOM 요소에 직접 상태를 저장하는 방식`을 사용하고 있음.
- 실제로 현재 코드는 DOM 요소를 *querySelector*로 불러온 뒤, `DOM 요소에 직접 접근`해 *innerHTML, appendChild, remove* 등의 메서드를 사용하여 동적으로 요소를 추가/업데이트/삭제하고 있음.
- DOM 요소에 직접 상태를 저장하는 방식은 개발자가 의도하지 않은 버그가 발생할 수 있어 권장되지 않음.
    - 예를 들어 DOM 요소 A, B가 있고, DOM 요소 B에 이벤트 리스너가 붙어있음. 이 때, 해당 이벤트 핸들러 내부 코드에서는 요소 A의 상태에 따라 특정 동작을 분기해 수행한다고 가정. DOM 요소 B에 이벤트가 발생해 이벤트 핸들러가 호출 되는 과정에서 요소 A의 상태가 변했을 때, 이벤트 핸들러 내부에서 요소 A를 가져온 시점에 따라 A의 상태 변화를 반영할수도, 반영하지 못할 수도 있음. 이런 코드는 버그에 취약함.

### 😆 v3: DOM에 접근하는 과정을 추상화 한 setState 함수 구현

- DOM 요소에 직접 상태를 저장하는 경우 발생하는 문제점을 해결하기 위해, `DOM 요소에 직접 상태를 저장하지 않고, 상태를 저장하는 별도의 장소를 둔 뒤, 상태가 변화할 때마다 자동으로 DOM 요소가 변화할 수 있도록 하는 상태 저장 방식`이 등장함.
    - *MVC, FLUX* 패턴을 적용한 *AngularJS, React-Redux* 같은 라이브러리들이 위 상태 저장 방식을 사용하고 있음.
    - 이러한 라이브러리에서는 개발자는 상태 변화가 필요한 경우, *setState*를 호출해주기만 하면 됨. 즉, 더 이상 DOM 요소를 조정하기 위해 *innerHTML, appendChilde, remove* 등의 DOM 메서드들을 호출할 필요가 없음.
        - 왜냐하면 *setState* 함수 내부에서 `(1) 인자로 받은 값으로 기존 상태를 업데이트` 시키고 `(2) 상태 변화에 맞게 사용자에게 보여질 DOM 요소를 조정`하는 작업을 자동으로 수행하기 때문.
        - 이 동작들은 ***setState*로 추상화**되어있기 때문에 더이상 개발자들은 DOM과 관련된 작업들을 고려할 필요가 없음.
        - 또한 (2)와 관련된 작업들은 *render* 함수로 추상화되어 있음.

<hr/>


# 🚀 [Trouble] 동일한 이벤트 핸들러의 중복 등록 문제

## 🙅🏻 기존 코드: 동일한 이벤트 핸들러의 중복 등록 문제 발생

```javascript      
let renderTimes = 0

const render = () => {
  renderTimes += 1

  const { menu } = state

  const form = $("form")
  const list = $("ul")

  list.innerHTML = `
  <ul id="espresso-menu-list" class="mt-3 pl-0">
   ${menu.map((name, idx) => createItem(name, idx)).join("")}		
  </ul>
  `

  // 메뉴 추가
  form.addEventListener("submit", (e) => {
    e.preventDefault()
    addMenu()
  })

  // 메뉴 수정/삭제
  list.addEventListener("click", (e) => {
    if (e.target.classList.contains("data-edit")) {
      updateMenu(e)
    }
    if (e.target.classList.contains("data-remove")) {
      removeMenu(e)
    }
  })
}

const setState = (newState) => {
  const prevState = state
  state = { ...state, ...newState }
  console.log(
    `[setState]: \n(prevState) ${JSON.stringify(prevState)} \n(currState) ${JSON.stringify(state)}`
  )
  render()
}

render()
```

-  *render* 함수 내에서 *addEventListener* 메서드 통해 이벤트 핸들러를 등록하는 방식 사용.
-  *setState* 통해 *state* 변경 할 때마다 *render* 호출 되기 때문에 *addEventListener*를 통해 동일한 이벤트 핸들러가 계속 등록됨.
-  즉, 하단 코드에서는 메뉴 추가, 변경, 삭제가 발생할 때마다 매번 *form, ul*에 이벤트 핸들러가 호출되어 버그가 생김. 🐞 
  -  메뉴 수정 시 *prompt* 창이 n(n≥ 1)회 이상 뜨고, 이는 2^n 꼴의 이벤트 핸들러 등록으로 이어짐. 😢 
  -  메뉴 삭제 시 confirm 창이 n(n≥ 1)회 이상 뜨고, 이는 2^n 꼴의 이벤트 핸들러 등록으로 이어짐. 더 나아가 index 기반 삭제 로직을 가진 함수 removeMenu에 의해 n(n≥1)개 이상의 메뉴가 동시에 지워지는 버그 발생. 😢 
  <div class="grid-image">
    <img src="https://media.giphy.com/media/D5x6vJIxg4CKJv32a8/giphy.gif" alt="메뉴 수정" width="45%">
    <img src="https://media.giphy.com/media/qOexgZAVVQ1jFc1NDk/giphy.gif" alt="메뉴 삭제" width="45%">
  </div> 
   
<hr/>

## 🙅🏻 1차 수정: addEventHandler 메서드의 등록 방식 활용한 이벤트 핸들러 중복 문제 해결

> `addEventHandler` 메서드 동작 방식
    - *addEventListener* 메서드 통해 등록한 이벤트 객체는 별도의 큐에 저장됨.
        - 단,  addEventListener 메서드로 이벤트 핸들러를 등록할 때, 큐에 저장된 객체 중 동일 이벤트, 동일 이벤트 핸들러를 가진 이벤트 객체가 이미 존재한다면, 중복으로 판단하고 이를 재등록하지 않음.
    - DOM 요소에서 특정 이벤트가 발생하면, DOM 요소는 자신의 큐에 저장된 이벤트 객체들을 순회하며, 동일한 이벤트에 등록된 이벤트 핸들러를 순서대로 수행함.
- 기존 코드는 addEventHandler 메서드에서 익명 함수 형태로 이벤트 핸들러를 전달하기 때문에, render 실행 시마다 신규 익명 함수가 전달됨. 따라서 addEventHandler 메서드는 매번 같은 내용의 코드를 보내도 이를 다른 이벤트 객체라고 판단하여 DOM 요소의 이벤트 객체 큐에 등록하게 됨.
- addEventHandler 메서드에서 동일 이벤트 객체임을 판단할 수 있도록, 전역 공간에 이벤트 핸들러를 선언하고, 해당 참조를 넘기는 방식으로 코드를 변환하면, addEventHandler 메서드 내장 로직에 의해 동일 이벤트 핸들러 중복 등록을 막을 수 있음.
    
    ```javascript
    /*
     * 동일 이벤트에 대해 동일한 이벤트를 여러 번 등록하지 않도록 하기 위해, 별도의 함수로 분리.
     * addEventListener는 이벤트 핸들러를 큐에 넣기 전, 참조 메모리 주소에 의해 동일성 여부 검사함.
     **/
    
    function addEventHandler(e) {
      e.preventDefault()
      addMenu()
    }
    
    function updateRemoveEventHandler(e) {
      if (e.target.classList.contains("data-edit")) {
        updateMenu(e)
      }
      if (e.target.classList.contains("data-remove")) {
        removeMenu(e)
      }
    }
    
    /*
     * render: 맨 처음이나 컴포넌트 상태 변화시 DOM 요소 조정 과정을 추상화한 함수
     **/
    const render = () => {
      const { menu } = state
    
      const form = $("form")
      const list = $("ul")
    
      list.innerHTML = `
    		<ul id="espresso-menu-list" class="mt-3 pl-0">
    			${menu.map((name, idx) => createItem(name, idx)).join("")}
    		</ul>
    	`
      // 메뉴 추가
      form.addEventListener("submit", addEventHandler)
    
      // 메뉴 수정/삭제
      list.addEventListener("click", updateRemoveEventHandler)
    
      updateTotal()
    }
    ```
<hr/>

## 🙆🏻 2차 수정: 이벤트 핸들러 등록을 render 외부로 이동
- 하지만 addEventListener 동작방식을 통한 수정 방식은 근본적인 문제해결 방식은 아님. 👎 
- ~~똑똑한 건 addEventListener지 현재 코드는 아주 멍청함.~~ 코드는 여전히 render 호출 시마다 새로운 이벤트 핸들러가 등록하려 하고 있음. addEventListener가 메모리 주소를 기반으로 동일 이벤트 핸들러임을 판단해 막아주고 있을 뿐.
    - 뿐만 아니라 1차 수정 코드는 코드 확장성이 좋지 않음. 만약 특정 DOM 요소에 동일한 이벤트 핸들러를 n번 호출되도록 하고 싶은 경우, 현재 로직에서는 조건문으로 복잡한 코드를 작성해야함… 😢
- 따라서 render 시마다 수행되는 것이 아니라 가장 처음 해당 컴포넌트가 렌더링 될 때만 실행될 수 있도록 이벤트 등록 코드를 render 함수에서 분리해주어야 함. 즉, *initialRender* 함수 선언하여 최초 렌더링 시에만 *setEvent* 함수 호출하도록 코드 작성하면, *addEventHandler*에게 즉시 실행 함수로 이벤트 핸들러 등록하더라도 개발자가 의도한 방식대로 코드가 동작함.
    ```javascript
    /*
     * setEventHandler: DOM 요소에 이벤트 핸들러 등록
     **/
    const setEventHandler = () => {
      const form = $("form")
      const list = $("ul")
    
      // 메뉴 추가
      form.addEventListener("submit", (e) => {
        e.preventDefault()
        addMenu()
      })
    
      // 메뉴 수정/삭제
      list.addEventListener("click", (e) => {
        if (e.target.classList.contains("data-edit")) {
          updateMenu(e)
        }
        if (e.target.classList.contains("data-remove")) {
          removeMenu(e)
        }
      })
    }
    
    /*
     * initialRender : 최초 렌더링 시에만 setEventHandler 수행해 이벤트 핸들러 등록
     **/
    const initialRender = () => {
      setEventHandler()
      render()
    }
    
    /*
     * render: 맨 처음이나 컴포넌트 상태 변화시 DOM 요소 조정 과정을 추상화한 함수
     **/
    const render = () => {
      const { menu } = state
    
      const list = $("ul")
    
      list.innerHTML = `
    		<ul id="espresso-menu-list" class="mt-3 pl-0">
    			${menu.map((name, idx) => createItem(name, idx)).join("")}
    		</ul>
    	`
    
      updateTotal()
    }
    
    initialRender()
    ```