### PR TITLE
(v2) Step2: Redux를 모방한 전역 상태 관리 흐름 설계

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 						<button data-category-name="teavana" class="cafe-category-name btn bg-white shadow mx-1">
 							🫖 티바나
 						</button>
-						<button data-category-name="desert" class="cafe-category-name btn bg-white shadow mx-1">
+						<button data-category-name="dessert" class="cafe-category-name btn bg-white shadow mx-1">
 							🍰 디저트
 						</button>
 					</nav>
@@ -42,20 +42,19 @@
 							<h2 class="mt-1">☕ 에스프레소 메뉴 관리</h2>
 							<span class="mr-2 mt-4 menu-count">총 0개</span>
 						</div>
-						<form id="espresso-menu-form">
+						<form id="menu-form">
 							<div class="d-flex w-100">
-								<label for="espresso-menu-name" class="input-label" hidden>
-									에스프레소 메뉴 이름
+								<label for="menu-name" class="input-label" hidden>
+									메뉴 이름
 								</label>
-								<input type="text" id="espresso-menu-name" name="espressoMenuName" class="input-field"
-									placeholder="에스프레소 메뉴 이름" autocomplete="off" />
-								<button type="submit" name="submit" id="espresso-menu-submit-button"
-									class="input-submit bg-green-600 ml-2">
+								<input type="text" id="menu-name" name="menuName" class="input-field" placeholder="메뉴 이름"
+									autocomplete="off" />
+								<button type="submit" name="submit" id="menu-submit-button" class="input-submit bg-green-600 ml-2">
 									확인
 								</button>
 							</div>
 						</form>
-						<ul id="espresso-menu-list" class="mt-3 pl-0"></ul>
+						<ul id="menu-list" class="mt-3 pl-0"></ul>
 					</div>
 				</main>
 			</div>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -70,22 +70,31 @@ const REMOVE_MENU = "remove-menu"
 const TOGGLE_MENU = "toggle-menu"
 
 /*
- * initialState: 초기 상태
+ * saveState: localStorage에 접근해 store의 state를 저장하는 함수
  */
-const initialState = {
-  menuList: {
-    [ESPRESSO]: [
-      { name: "long black", soldOut: false },
-      { name: "americano", soldOut: false },
-      { name: "espresso con panna", soldOut: false },
-      { name: "lattte", soldOut: false },
-      { name: "cafe mocha", soldOut: false },
-    ],
-    [FRAPPUCINO]: [],
-    [BLENDED]: [],
-    [TEAVANA]: [],
-    [DESSERT]: [],
-  },
+function saveState() {
+  const state = store.getState()
+  localStorage.setItem("state", JSON.stringify(state))
+}
+
+function getInitState() {
+  const savedState = JSON.parse(localStorage.getItem("state"))
+
+  if (savedState !== null) {
+    return savedState
+  }
+
+  const stateTemplate = {
+    menuList: {
+      [ESPRESSO]: [],
+      [FRAPPUCINO]: [],
+      [BLENDED]: [],
+      [TEAVANA]: [],
+      [DESSERT]: [],
+    },
+  }
+
+  return stateTemplate
 }
 
 let componentState = {
@@ -94,7 +103,7 @@ let componentState = {
 
 // TODO const로 선언하면 블록 내에서 같은 변수명 재사용 불가 -> 클린 코드?
 // reducer는 디폴트값으로 initialState 받음
-function reducer(state = initialState, action) {
+function reducer(state = getInitState(), action) {
   // 기존 state값을 복사한 신규 객체를 만들고, 변경 사항을 반영하여 반환함.
   const { type, payload } = action
   const { tab } = componentState
@@ -154,13 +163,15 @@ const store = createStore(reducer)
 store.subscribe(function () {
   console.log("[Global State Changed]", store.getState())
 })
-
+store.subscribe(saveState)
 store.subscribe(render)
+
+initialRender()
 
 /*
  * initialRender : 최초 렌더링 시에만 setEventHandler 수행해 이벤트 핸들러 등록
  **/
-const initialRender = () => {
+function initialRender() {
   setEventHandler()
   render()
 }
@@ -185,7 +196,7 @@ function render() {
 /*
  * setState: 컴포넌트 내부 상태 업데이트 하는 과정을 추상화한 함수
  **/
-const setState = (newState) => {
+function setState(newState) {
   const prevState = componentState
   componentState = { ...componentState, ...newState }
   console.log(
@@ -195,8 +206,6 @@ const setState = (newState) => {
   )
   render()
 }
-
-initialRender()
 
 /*
  * setEventHandler: DOM 요소에 이벤트 핸들러 등록

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -13,7 +13,48 @@
  * **********************************************************************
  **/
 
+/*
+ * **********************************************************************
+ * Step2
+ * [ ] localStorage에 데이터를 저장하여 새로고침해도 데이터가 남아있게 한다.
+ * [ ] 에스프레소, 프라푸치노, 블렌디드, 티바나, 디저트 각각의 종류별로 메뉴판을 관리할 수 있게 만든다.
+ * [ ] 페이지에 최초로 접근할 때는 에스프레소 메뉴가 먼저 보이게 한다.
+ * [ ] 품절 상태인 경우를 보여줄 수 있게, 품절 버튼을 추가하고 sold-out class를 추가하여 상태를 변경한다.
+ * (v1) 상태 관리로 메뉴 관리하기
+ *
+ * **********************************************************************
+ **/
+
 const $ = (selector) => document.querySelector(selector)
+
+function createStore(reducer) {
+  let state
+  let callbacks = []
+
+  function dispatch(action) {
+    // state 불변성 유지. state는 오직 store 내에서만 변경 가능.
+    state = reducer(state, action)
+    // state 변경 시마다 등록된 콜백함수들 동기적으로 호출
+    callbacks.forEach((callback) => callback())
+  }
+
+  function subscribe(callback) {
+    callbacks.push(callback)
+  }
+
+  function getState() {
+    return state
+  }
+
+  // 클로저로 private state, private callbacks 구현해 정보 은닉
+  return {
+    dispatch,
+    subscribe,
+    getState,
+  }
+}
+
+const initialState = {}
 
 /*
  * state: 전역 상태
@@ -28,6 +69,23 @@ let state = {
     "cappucino",
   ],
 }
+
+// reducer는 디폴트값으로 initialState 받음
+function reducer(state = initialState, action) {
+  switch (action.type) {
+    case ACTIONTYPE1:
+      // 기존 state값을 복사한 신규 객체를 만들고, 변경 사항을 반영하여 반환함.
+      return { ...state }
+    default:
+      return { ...state }
+  }
+}
+
+const store = createStore(reducer)
+
+store.subscribe(function () {
+  console.log(store.getState())
+})
 
 /*
  * initialRender : 최초 렌더링 시에만 setEventHandler 수행해 이벤트 핸들러 등록

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -146,6 +146,7 @@ const getInitState = () => {
   const savedState = JSON.parse(localStorage.getItem("state"));
 
   if (savedState !== null) {
+    savedState.tab = ESPRESSO;
     return savedState;
   }
 
@@ -157,6 +158,7 @@ const getInitState = () => {
       [TEAVANA]: [],
       [DESSERT]: [],
     },
+    tab: ESPRESSO,
   };
 
   return stateTemplate;
@@ -173,7 +175,8 @@ const getInitState = () => {
  */
 const reducer = (state = getInitState(), action) => {
   const { type, payload } = action;
-  const { tab } = componentState;
+  const { tab } = state;
+
   switch (type) {
     case INIT_MENU:
       return { ...state };

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -74,21 +74,23 @@ let componentState = {
   tab: ESPRESSO,
 };
 
-/*
- * actionCreator: type과 payload를 받아 action 객체를 반환하는 함수
- * TODO 커링 함수로 변경: 지연 실행
+/**
+ * @function actionCreator
+ * @description type과 payload를 받아 action 객체를 반환하는 함수
+ * @todo 커링 함수로 변경: 지연 실행
  */
 const actionCreator = (type, payload) => {
   return { type, payload };
 };
 
 /**
- * createStore(reducer): 전역 상태관리를 수행하는 store 객체를 반환하는 함수
- * store 객체에 dispatch, subscribe, getState 메서드만 반환하여, state 정보 은닉(클로저).
- * reducer: store에서 상태 변경을 위임하는 함수
- * (1) dispatch(action): 특정 action이 발생했음을 알려, store에서 상태를 변경하도록 함.
- * (2) subscribe(callback): store에서 상태 변경이 수행된 후, 호출할 함수들을 전달함.
- * (3) getState(): store의 현재 상태를 반환함.
+ * @function createStore
+ * @param {function} reducer
+ * @description 전역 상태관리를 수행하는 store 객체를 반환하는 함수.
+ * 							store 객체에 dispatch, subscribe, getState 메서드만 반환하여, state 정보 은닉(클로저).
+ * 							(1) dispatch(action): 특정 action이 발생했음을 알려, store에서 상태를 변경하도록 함.
+ * 							(2) subscribe(callback): store에서 상태 변경이 수행된 후, 호출할 함수들을 전달함.
+ * 							(3) getState(): store의 현재 상태를 반환함.
  */
 const createStore = (reducer) => {
   let state;
@@ -121,7 +123,8 @@ const createStore = (reducer) => {
 };
 
 /**
- * saveState: localStorage에 접근해 store의 state를 저장하는 함수
+ * @function savedState
+ * @description localStorage에 접근해 store의 state를 저장하는 함수
  */
 const saveState = () => {
   const state = store.getState();
@@ -129,7 +132,8 @@ const saveState = () => {
 };
 
 /**
- * getInitState: localStorage에서 초기 상태값을 가져오는 함수
+ * @function getInitState
+ * @description localStorage에서 초기 상태값을 가져오는 함수
  */
 const getInitState = () => {
   const savedState = JSON.parse(localStorage.getItem("state"));
@@ -152,10 +156,13 @@ const getInitState = () => {
 };
 
 /**
- * reducer(state, action): state를 복제한 객체에 action.type에 따라 상태 변경을 반영한 결과를 반환하는 함수
- * TODO const로 선언하면 블록 내에서 같은 변수명 재사용 불가 -> 클린 코드?
- * TODO reducer는 디폴트값으로 initialState받을 때, localStorage를 연결하는게 맞을까?
- * TODO 최대한 Flat하게 state를 변경하거나 immutable.js 사용하거나 deepcopy 수행하는 코드로 변경하기
+ * @function reducer
+ * @param {Object} state
+ * @param {Object} action
+ * @description state를 복제한 객체에 action.type에 따라 상태 변경을 반영한 결과를 반환하는 함수
+ * @toddo const로 선언하면 블록 내에서 같은 변수명 재사용 불가 -> 클린 코드?
+ * @todo reducer는 디폴트값으로 initialState받을 때, localStorage를 연결하는게 맞을까?
+ * @todo 최대한 Flat하게 state를 변경하거나 immutable.js 사용하거나 deepcopy 수행하는 코드로 변경하기
  */
 const reducer = (state = getInitState(), action) => {
   const { type, payload } = action;
@@ -210,6 +217,12 @@ const reducer = (state = getInitState(), action) => {
  * 하단 함수들은 setState나 dispatch를 통해 상태 변경 요청만 보냄
  * 즉, 요청을 보낸 뒤, 따로 DOM 조작에 신경 쓸 필요 없음
  */
+
+/**
+ * @function changeTab
+ * @param {Event} e
+ * @description	사용자가 네비게이션 바에서 탭 전환시 탭 상태 변경하는 함수
+ */
 const changeTab = (e) => {
   const { tab: currTab } = componentState;
   const newTab = e.target.dataset.categoryName;
@@ -218,6 +231,10 @@ const changeTab = (e) => {
   setState({ tab: newTab });
 };
 
+/**
+ * @function addMenu
+ * @description 사용자가 input에 메뉴명을 기입한 뒤, enter를 누르거나 제출 버튼을 누른 경우 메뉴를 추가함
+ */
 const addMenu = () => {
   const input = $("input");
 
@@ -231,6 +248,11 @@ const addMenu = () => {
   input.value = "";
 };
 
+/**
+ * @function updateMenu
+ * @param {Event} e
+ * @description 사용자가 수정 버튼을 누른 뒤, confirm에 수정 메뉴 이름을 기입하면, 헤당 메뉴의 이름을 수정함
+ */
 const updateMenu = (e) => {
   const prevName = e.target.closest("li").querySelector("span").innerText;
   const updateIdx = Number(e.target.dataset.index);
@@ -249,6 +271,11 @@ const updateMenu = (e) => {
   // })
 };
 
+/**
+ * @function removeMenu
+ * @param {Event} e
+ * @description 사용자가 삭제 버튼을 누르면, 해당 메뉴를 삭제함
+ */
 const removeMenu = (e) => {
   const ret = confirm("정말 삭제하시겠습니까?");
   if (!ret) return;
@@ -262,6 +289,11 @@ const removeMenu = (e) => {
   // })
 };
 
+/**
+ * @function toggleMenu
+ * @param {Event} e
+ * @description 사용자가 품절 버튼 누르면 해당 메뉴 품절 여부를 토글함
+ */
 const toggleMenu = (e) => {
   const toggleIdx = Number(e.target.dataset.index);
 
@@ -269,8 +301,8 @@ const toggleMenu = (e) => {
 };
 
 /**
- * setEventHandler: DOM 요소에 이벤트 핸들러 등록
- * TODO 향후 추상화하려면 모든 이벤트를 최상위객체 .app에 위임
+ * @function setEventHandler
+ * @description DOM 요소에 직접 접근해 이벤트 핸들러 등록
  */
 const setEventHandler = () => {
   const app = $("#app");
@@ -314,6 +346,11 @@ const setEventHandler = () => {
  * 하단의 updateTotal, updateTitle은 DOM 요소에 직접 접근하여 DOM 요소를 조작하여 직접 렌더링 수행
  * TODO updateTotal, updateTitle에서 DOM 직접조작 하지 않도록 렌더링 로직 분리하기(추상화 할 때 적용하기)
  */
+
+/**
+ * @function updateTotal
+ * @description 상단바의 총 메뉴 개수를 업데이트
+ */
 const updateTotal = () => {
   const { menuList } = store.getState();
   const { tab } = componentState;
@@ -322,6 +359,10 @@ const updateTotal = () => {
   cnt.innerText = `총 ${menu.length}개`;
 };
 
+/**
+ * @function updateTitle
+ * @description 상단바의 메뉴 카테고리명 업데이트
+ */
 const updateTitle = () => {
   const { tab } = componentState;
   const title = $("h2");
@@ -335,7 +376,10 @@ const updateTitle = () => {
 };
 
 /**
- * template: render 내부에서 menu 상태를 받아 HTML 태그 구조를 반환하는 함수
+ * @function template
+ * @param {Object} menu
+ * @description 렌더링 시 상태에서 메뉴 리스트를 바탕으로 HTML 템플릿을 생성해 리턴하는 함수
+ *
  */
 const template = (menu) => {
   return menu
@@ -371,10 +415,12 @@ const template = (menu) => {
     .join("");
 };
 
-/*
- * render: 맨 처음이나 컴포넌트 상태 변화시 DOM 요소 조정 과정을 추상화한 함수
- * TODO globalState, ComponentState 변경이 요소 전체가 리렌더링으로 이어지는 맥락 파악하기
- **/
+/**
+ * @function render
+ * @description DOM 요소에 직접 접근해 조작하는 과정을 추상화 함수
+ * 							페이지 최초 렌더링 시나 컴포넌트 상태 변화시 호출됨
+ * @todo globalState, ComponentState 변경이 요소 전체가 리렌더링으로 이어지는 맥락 파악하기
+ */
 const render = () => {
   const { menuList } = store.getState();
   const { tab } = componentState;
@@ -388,16 +434,21 @@ const render = () => {
   updateTitle();
 };
 
-/*
- * initialRender : 최초 렌더링 시에만 setEventHandler 수행해 이벤트 핸들러 등록
- **/
+/**
+ * @function initialRender
+ * @description 최초 렌더링 시, setEventHandler 호출해 이벤트 핸들러 등록
+ */
 const initialRender = () => {
   setEventHandler();
   render();
 };
 
 /**
- * setState: 컴포넌트 내부 상태 업데이트 하는 과정을 추상화한 함수
+ * @function setState
+ * @param {Object} newState
+ * @description 컴포넌트 내부 상태 업데이트 하는 과정 추상화 함수
+ * 							기존 상태를 복제한 신규 상태 객체를 만든 뒤, 업데이트를 진행하므로 상태의 불변성 유지됨.
+ * 							상태 변화시 변경 전 상태와 변경 후 상태를 console에 출력
  */
 const setState = (newState) => {
   const prevState = componentState;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -20,7 +20,7 @@
  * [v] 에스프레소, 프라푸치노, 블렌디드, 티바나, 디저트 각각의 종류별로 메뉴판을 관리할 수 있게 만든다.
  * [v] 페이지에 최초로 접근할 때는 에스프레소 메뉴가 먼저 보이게 한다.
  * [v] 품절 상태인 경우를 보여줄 수 있게, 품절 버튼을 추가하고 sold-out class를 추가하여 상태를 변경한다.
- * (v1) 상태 관리로 메뉴 관리하기
+ * (v2) redux 모방해 상태 관리로 메뉴 관리하기
  * - createStore 메서드 통해 전역 상태 관리에 사용할 dispatch, subscribe, getState 메서드를 가진 객체 store 반환
  * - 메뉴 추가/업데이트/삭제/메뉴 품절 여부 표시 이벤트 핸들러의 setState를 store.dispatch(actionCreator(type, payload)) 형태로 수정
  * - 즉, 메뉴 관련 이벤트가 발생하면, actionCreator가 action 객체를 만들어 반환하여 dispatch에 전달

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,4 +1,4 @@
-/*
+/**
  * **********************************************************************
  * Step1
  * (v1) DOM 조작과 이벤트 핸들링으로 메뉴 CRUD
@@ -11,9 +11,9 @@
  * - (2) 상태 변화에 맞게 사용자에게 보여질 DOM 요소 조정 코드 render 함수로 추상화
  * - 이벤트 등록 함수 render 외부로 분리해 중복 등록 이슈 해결
  * **********************************************************************
- **/
+ */
 
-/*
+/**
  * **********************************************************************
  * Step2
  * [v] localStorage에 데이터를 저장하여 새로고침해도 데이터가 남아있게 한다.
@@ -31,7 +31,7 @@
  * - 상태 변경 시마다 localStorage에 신규 상태가 반영되고, 리렌더링이 일어날 수 있도록 해당 메서드들을 store.subscribe(메서드)에 전달함
  * - store의 상태에 접근해야 할 때, 항상 store.getState() 메서드를 통해 접근
  * **********************************************************************
- **/
+ */
 
 // NOTION KEYWORD
 // 카테고리 명칭 상수화: 휴먼 에러 방지 - 실제 desert 사례
@@ -47,42 +47,42 @@
 // TODO 최대한 Flat하게 state를 변경하거나 immutable.js 사용하거나 deepcopy 수행하는 코드로 변경하기
 // TODO updateTotal, updateTitle에서 DOM 직접조작 하지 않도록 렌더링 로직 분리하기(추상화 할 때 적용하기)
 
-/*
+/**
  * MENU_CATEGORIES: 카테고리 명칭
  */
-const ESPRESSO = "espresso"
-const FRAPPUCINO = "frappuccino"
-const BLENDED = "blended"
-const TEAVANA = "teavana"
-const DESSERT = "dessert"
+const ESPRESSO = "espresso";
+const FRAPPUCINO = "frappuccino";
+const BLENDED = "blended";
+const TEAVANA = "teavana";
+const DESSERT = "dessert";
 
-/*
+/**
  * ACTION_TYPES: 액션 타입 명칭
  */
-const INIT_MENU = "init-menu"
-const ADD_MENU = "add-menu"
-const UPDATE_MENU = "update-menu"
-const REMOVE_MENU = "remove-menu"
-const TOGGLE_MENU = "toggle-menu"
+const INIT_MENU = "init-menu";
+const ADD_MENU = "add-menu";
+const UPDATE_MENU = "update-menu";
+const REMOVE_MENU = "remove-menu";
+const TOGGLE_MENU = "toggle-menu";
 
-const $ = (selector) => document.querySelector(selector)
+const $ = (selector) => document.querySelector(selector);
 
-/*
+/**
  * componentState: 컴포넌트 내부에서 관리하는 상태
  */
 let componentState = {
   tab: ESPRESSO,
-}
+};
 
 /*
  * actionCreator: type과 payload를 받아 action 객체를 반환하는 함수
  * TODO 커링 함수로 변경: 지연 실행
  */
 const actionCreator = (type, payload) => {
-  return { type, payload }
-}
+  return { type, payload };
+};
 
-/*
+/**
  * createStore(reducer): 전역 상태관리를 수행하는 store 객체를 반환하는 함수
  * store 객체에 dispatch, subscribe, getState 메서드만 반환하여, state 정보 은닉(클로저).
  * reducer: store에서 상태 변경을 위임하는 함수
@@ -91,25 +91,25 @@ const actionCreator = (type, payload) => {
  * (3) getState(): store의 현재 상태를 반환함.
  */
 const createStore = (reducer) => {
-  let state
-  let callbacks = []
+  let state;
+  let callbacks = [];
 
-  dispatch(actionCreator(INIT_MENU, {}))
+  dispatch(actionCreator(INIT_MENU, {}));
 
   function dispatch(action) {
     // state 불변성 유지. state는 오직 store 내에서만 변경 가능.
-    state = reducer(state, action)
+    state = reducer(state, action);
     // state 변경 시마다 등록된 콜백함수들 동기적으로 호출
-    callbacks.forEach((callback) => callback())
+    callbacks.forEach((callback) => callback());
   }
 
   function subscribe(callback) {
-    callbacks.push(callback)
+    callbacks.push(callback);
   }
 
   function getState() {
-    return state
-    return { ...state } // TODO 차이?
+    return state;
+    return { ...state }; // TODO 차이?
   }
 
   // 클로저로 private state, private callbacks 구현해 정보 은닉
@@ -117,25 +117,25 @@ const createStore = (reducer) => {
     dispatch,
     subscribe,
     getState,
-  }
-}
+  };
+};
 
-/*
+/**
  * saveState: localStorage에 접근해 store의 state를 저장하는 함수
  */
 const saveState = () => {
-  const state = store.getState()
-  localStorage.setItem("state", JSON.stringify(state))
-}
+  const state = store.getState();
+  localStorage.setItem("state", JSON.stringify(state));
+};
 
-/*
+/**
  * getInitState: localStorage에서 초기 상태값을 가져오는 함수
  */
 const getInitState = () => {
-  const savedState = JSON.parse(localStorage.getItem("state"))
+  const savedState = JSON.parse(localStorage.getItem("state"));
 
   if (savedState !== null) {
-    return savedState
+    return savedState;
   }
 
   const stateTemplate = {
@@ -146,100 +146,100 @@ const getInitState = () => {
       [TEAVANA]: [],
       [DESSERT]: [],
     },
-  }
+  };
 
-  return stateTemplate
-}
+  return stateTemplate;
+};
 
-/*
+/**
  * reducer(state, action): state를 복제한 객체에 action.type에 따라 상태 변경을 반영한 결과를 반환하는 함수
  * TODO const로 선언하면 블록 내에서 같은 변수명 재사용 불가 -> 클린 코드?
  * TODO reducer는 디폴트값으로 initialState받을 때, localStorage를 연결하는게 맞을까?
  * TODO 최대한 Flat하게 state를 변경하거나 immutable.js 사용하거나 deepcopy 수행하는 코드로 변경하기
  */
 const reducer = (state = getInitState(), action) => {
-  const { type, payload } = action
-  const { tab } = componentState
+  const { type, payload } = action;
+  const { tab } = componentState;
   switch (type) {
     case INIT_MENU:
-      return { ...state }
+      return { ...state };
     case ADD_MENU:
-      const { name } = payload
-      const newItem = { name, soldOut: false }
+      const { name } = payload;
+      const newItem = { name, soldOut: false };
       return {
         ...state,
         menuList: {
           ...state.menuList,
           [tab]: [...state.menuList[tab], newItem],
         },
-      }
+      };
     case UPDATE_MENU:
-      const { updateIdx, newName } = payload
+      const { updateIdx, newName } = payload;
       const updatedMenu = state.menuList[tab].map((item, idx) => {
         if (idx === updateIdx) {
-          const updatedItem = { ...item, name: newName }
-          return updatedItem
+          const updatedItem = { ...item, name: newName };
+          return updatedItem;
         }
-        return item
-      })
-      return { ...state, menuList: { ...state.menuList, [tab]: updatedMenu } }
+        return item;
+      });
+      return { ...state, menuList: { ...state.menuList, [tab]: updatedMenu } };
     case REMOVE_MENU:
-      const { removeIdx } = payload
+      const { removeIdx } = payload;
       const removedMenu = state.menuList[tab].filter(
         (_, idx) => idx !== removeIdx
-      )
-      return { ...state, menuList: { ...state.menuList, [tab]: removedMenu } }
+      );
+      return { ...state, menuList: { ...state.menuList, [tab]: removedMenu } };
     case TOGGLE_MENU:
-      const { toggleIdx } = payload
+      const { toggleIdx } = payload;
       const toggledMenu = state.menuList[tab].map((item, idx) => {
         if (idx === toggleIdx) {
-          const toggledItem = { ...item, soldOut: !item.soldOut }
-          return toggledItem
+          const toggledItem = { ...item, soldOut: !item.soldOut };
+          return toggledItem;
         }
-        return item
-      })
-      return { ...state, menuList: { ...state.menuList, [tab]: toggledMenu } }
+        return item;
+      });
+      return { ...state, menuList: { ...state.menuList, [tab]: toggledMenu } };
     default:
-      return { ...state }
+      return { ...state };
   }
-}
+};
 
-/*
+/**
  * 하단의 changeTab, addMenu, updateMenu, removeMenu, toggleMenu는 이벤트 핸들러로 등록되는 함수
  * DOM 요소에는 사용자 입력값을 가져올 때만 접근하는 것 외에 직접 접근 하지 않음
  * 하단 함수들은 setState나 dispatch를 통해 상태 변경 요청만 보냄
  * 즉, 요청을 보낸 뒤, 따로 DOM 조작에 신경 쓸 필요 없음
- **/
+ */
 const changeTab = (e) => {
-  const { tab: currTab } = componentState
-  const newTab = e.target.dataset.categoryName
+  const { tab: currTab } = componentState;
+  const newTab = e.target.dataset.categoryName;
 
-  if (currTab === newTab) return
-  setState({ tab: newTab })
-}
+  if (currTab === newTab) return;
+  setState({ tab: newTab });
+};
 
 const addMenu = () => {
-  const input = $("input")
+  const input = $("input");
 
-  const name = input.value
+  const name = input.value;
 
-  if (!name) return
+  if (!name) return;
 
-  store.dispatch(actionCreator(ADD_MENU, { name }))
+  store.dispatch(actionCreator(ADD_MENU, { name }));
   // setState({ menu: [...menu, name] }) // setState 통해 메뉴 추가시 자동으로 DOM 요소 처리함
 
-  input.value = ""
-}
+  input.value = "";
+};
 
 const updateMenu = (e) => {
-  const prevName = e.target.closest("li").querySelector("span").innerText
-  const updateIdx = Number(e.target.dataset.index)
+  const prevName = e.target.closest("li").querySelector("span").innerText;
+  const updateIdx = Number(e.target.dataset.index);
 
-  const newName = prompt("메뉴명을 수정하세요", prevName)
+  const newName = prompt("메뉴명을 수정하세요", prevName);
 
-  if (newName === null) return
+  if (newName === null) return;
 
-  store.dispatch(actionCreator(UPDATE_MENU, { updateIdx, newName }))
+  store.dispatch(actionCreator(UPDATE_MENU, { updateIdx, newName }));
   // setState 통해 메뉴 업데이트 시 자동으로 DOM 요소 처리함
   // setState({
   //   menu: menu.map((name, idx) => {
@@ -247,96 +247,96 @@ const updateMenu = (e) => {
   //     return name
   //   }),
   // })
-}
+};
 
 const removeMenu = (e) => {
-  const ret = confirm("정말 삭제하시겠습니까?")
-  if (!ret) return
+  const ret = confirm("정말 삭제하시겠습니까?");
+  if (!ret) return;
 
-  const removeIdx = Number(e.target.dataset.index)
+  const removeIdx = Number(e.target.dataset.index);
 
-  store.dispatch(actionCreator(REMOVE_MENU, { removeIdx }))
+  store.dispatch(actionCreator(REMOVE_MENU, { removeIdx }));
   // setState 통해 메뉴 삭제 시 자동으로 DOM 요소 처리함
   // setState({
   //   menu: menu.filter((_, idx) => index !== idx),
   // })
-}
+};
 
 const toggleMenu = (e) => {
-  const toggleIdx = Number(e.target.dataset.index)
+  const toggleIdx = Number(e.target.dataset.index);
 
-  store.dispatch(actionCreator(TOGGLE_MENU, { toggleIdx }))
-}
+  store.dispatch(actionCreator(TOGGLE_MENU, { toggleIdx }));
+};
 
-/*
+/**
  * setEventHandler: DOM 요소에 이벤트 핸들러 등록
  * TODO 향후 추상화하려면 모든 이벤트를 최상위객체 .app에 위임
- **/
+ */
 const setEventHandler = () => {
-  const app = $("#app")
-  const form = $("form")
+  const app = $("#app");
+  const form = $("form");
 
   form.addEventListener("submit", (e) => {
-    e.preventDefault()
-  })
+    e.preventDefault();
+  });
 
   // 메뉴탭 전환
   app.addEventListener("click", (e) => {
     if (e.target.classList.contains("cafe-category-name")) {
-      changeTab(e)
-      return
+      changeTab(e);
+      return;
     }
-  })
+  });
 
   // 메뉴 추가
   app.addEventListener("submit", () => {
-    addMenu()
-  })
+    addMenu();
+  });
 
   // 메뉴 토글/수정/삭제
   app.addEventListener("click", (e) => {
     if (e.target.classList.contains("toggle-btn")) {
-      toggleMenu(e)
-      return
+      toggleMenu(e);
+      return;
     }
     if (e.target.classList.contains("edit-btn")) {
-      updateMenu(e)
-      return
+      updateMenu(e);
+      return;
     }
     if (e.target.classList.contains("remove-btn")) {
-      removeMenu(e)
-      return
+      removeMenu(e);
+      return;
     }
-  })
-}
+  });
+};
 
-/*
+/**
  * 하단의 updateTotal, updateTitle은 DOM 요소에 직접 접근하여 DOM 요소를 조작하여 직접 렌더링 수행
  * TODO updateTotal, updateTitle에서 DOM 직접조작 하지 않도록 렌더링 로직 분리하기(추상화 할 때 적용하기)
- **/
+ */
 const updateTotal = () => {
-  const { menuList } = store.getState()
-  const { tab } = componentState
-  const menu = menuList[tab]
-  const cnt = $(".menu-count")
-  cnt.innerText = `총 ${menu.length}개`
-}
+  const { menuList } = store.getState();
+  const { tab } = componentState;
+  const menu = menuList[tab];
+  const cnt = $(".menu-count");
+  cnt.innerText = `총 ${menu.length}개`;
+};
 
 const updateTitle = () => {
-  const { tab } = componentState
-  const title = $("h2")
+  const { tab } = componentState;
+  const title = $("h2");
 
-  const categories = document.querySelectorAll("nav > button")
+  const categories = document.querySelectorAll("nav > button");
   const currCategory = Array.from(categories).find(
     (category) => category.dataset.categoryName === tab
-  ).innerText
+  ).innerText;
 
-  title.innerText = `${currCategory} 메뉴 관리`
-}
+  title.innerText = `${currCategory} 메뉴 관리`;
+};
 
-/*
+/**
  * template: render 내부에서 menu 상태를 받아 HTML 태그 구조를 반환하는 함수
- **/
+ */
 const template = (menu) => {
   return menu
     .map(
@@ -368,58 +368,58 @@ const template = (menu) => {
 			</li>
 			`
     )
-    .join("")
-}
+    .join("");
+};
 
 /*
  * render: 맨 처음이나 컴포넌트 상태 변화시 DOM 요소 조정 과정을 추상화한 함수
  * TODO globalState, ComponentState 변경이 요소 전체가 리렌더링으로 이어지는 맥락 파악하기
  **/
 const render = () => {
-  const { menuList } = store.getState()
-  const { tab } = componentState
-  const currTabMenu = menuList[tab]
+  const { menuList } = store.getState();
+  const { tab } = componentState;
+  const currTabMenu = menuList[tab];
 
-  const list = $("ul")
+  const list = $("ul");
 
-  list.innerHTML = template(currTabMenu)
+  list.innerHTML = template(currTabMenu);
 
-  updateTotal()
-  updateTitle()
-}
+  updateTotal();
+  updateTitle();
+};
 
 /*
  * initialRender : 최초 렌더링 시에만 setEventHandler 수행해 이벤트 핸들러 등록
  **/
 const initialRender = () => {
-  setEventHandler()
-  render()
-}
+  setEventHandler();
+  render();
+};
 
-/*
+/**
  * setState: 컴포넌트 내부 상태 업데이트 하는 과정을 추상화한 함수
- **/
+ */
 const setState = (newState) => {
-  const prevState = componentState
-  componentState = { ...componentState, ...newState }
+  const prevState = componentState;
+  componentState = { ...componentState, ...newState };
   console.log(
     `[setState]: \n(prevState) ${JSON.stringify(
       prevState
     )} \n(currState) ${JSON.stringify(componentState)}`
-  )
-  render()
-}
+  );
+  render();
+};
 
-/*
+/**
  * 메인 코드 실행
  */
 
-const store = createStore(reducer)
+const store = createStore(reducer);
 
 store.subscribe(function () {
-  console.log("[Global State Changed]", store.getState())
-})
-store.subscribe(saveState)
-store.subscribe(render)
+  console.log("[Global State Changed]", store.getState());
+});
+store.subscribe(saveState);
+store.subscribe(render);
 
-initialRender()
+initialRender();

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -45,7 +45,6 @@
 // TODO const로 선언하면 블록 내에서 같은 변수명 재사용 불가 -> 클린 코드?
 // TODO reducer는 디폴트값으로 initialState받을 때, localStorage를 연결하는게 맞을까?
 // TODO 최대한 Flat하게 state를 변경하거나 immutable.js 사용하거나 deepcopy 수행하는 코드로 변경하기
-// TODO 향후 추상화하려면 모든 이벤트를 최상위객체 .app에 위임
 // TODO updateTotal, updateTitle에서 DOM 직접조작 하지 않도록 렌더링 로직 분리하기(추상화 할 때 적용하기)
 
 /*
@@ -216,7 +215,6 @@ const changeTab = (e) => {
   const newTab = e.target.dataset.categoryName
 
   if (currTab === newTab) return
-
   setState({ tab: newTab })
 }
 
@@ -275,31 +273,38 @@ const toggleMenu = (e) => {
  * TODO 향후 추상화하려면 모든 이벤트를 최상위객체 .app에 위임
  **/
 const setEventHandler = () => {
-  const nav = $("nav")
+  const app = $("#app")
   const form = $("form")
-  const list = $("ul")
 
-  // 메뉴탭 전환
-  nav.addEventListener("click", changeTab)
-
-  // 메뉴 추가
   form.addEventListener("submit", (e) => {
     e.preventDefault()
+  })
+
+  // 메뉴탭 전환
+  app.addEventListener("click", (e) => {
+    if (e.target.classList.contains("cafe-category-name")) {
+      changeTab(e)
+      return
+    }
+  })
+
+  // 메뉴 추가
+  app.addEventListener("submit", () => {
     addMenu()
   })
 
-  // 메뉴 수정/삭제
-  list.addEventListener("click", (e) => {
-    if (e.target.classList.contains("data-edit")) {
+  // 메뉴 토글/수정/삭제
+  app.addEventListener("click", (e) => {
+    if (e.target.classList.contains("toggle-btn")) {
+      toggleMenu(e)
+      return
+    }
+    if (e.target.classList.contains("edit-btn")) {
       updateMenu(e)
       return
     }
-    if (e.target.classList.contains("data-remove")) {
+    if (e.target.classList.contains("remove-btn")) {
       removeMenu(e)
-      return
-    }
-    if (e.target.classList.contains("data-toggle")) {
-      toggleMenu(e)
       return
     }
   })
@@ -341,21 +346,21 @@ const template = (menu) => {
 				<span class="w-100 pl-2 menu-name ${soldOut ? "sold-out" : ""}">${name}</span>
 				<button
 					type="button"
-					class="bg-gray-50 text-gray-500 text-sm mr-1 menu-sold-out-button data-toggle"
+					class="bg-gray-50 text-gray-500 text-sm mr-1 menu-sold-out-button toggle-btn"
 					data-index=${idx}
 				>
 					품절
 				</button>
 				<button
 					type="button"
-					class="bg-gray-50 text-gray-500 text-sm mr-1 menu-edit-button data-edit"
+					class="bg-gray-50 text-gray-500 text-sm mr-1 menu-edit-button edit-btn"
 					data-index=${idx}
 				>
 					수정
 				</button>
 				<button
 					type="button"
-					class="bg-gray-50 text-gray-500 text-sm menu-remove-button data-remove"
+					class="bg-gray-50 text-gray-500 text-sm menu-remove-button remove-btn"
 					data-index=${idx}
 				>
 					삭제

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -103,33 +103,30 @@ function reducer(state = initialState, action) {
     case ADD_MENU:
       const { name } = payload
       const newItem = { name, soldOut: false }
-      console.log(state)
-      console.log(...state)
-      return { ...state, [tab]: [...state.menuList[tab], newItem] }
+      // TODO 최대한 Flat하게 state를 변경하거나 immutable.js 사용하거나 deepcopy 수행
+      return {
+        ...state,
+        menuList: {
+          ...state.menuList,
+          [tab]: [...state.menuList[tab], newItem],
+        },
+      }
     case UPDATE_MENU:
       const { updateIdx, newName } = payload
-      const updatedMenu = state[tab].map((item, idx) => {
+      const updatedMenu = state.menuList[tab].map((item, idx) => {
         if (idx === updateIdx) {
           const updatedItem = { ...item, name: newName }
           return updatedItem
         }
         return item
       })
-      return { ...state, [tab]: updatedMenu }
+      return { ...state, menuList: { ...state.menuList, [tab]: updatedMenu } }
     case REMOVE_MENU:
       const { removeIdx } = payload
-      const removedMenu = state[tab].filter((item) => item.idx !== removeIdx)
-      return { ...state, [tab]: removedMenu }
-    case TOGGLE_MENU:
-      const { toggleIdx } = payload
-      const toggledMenu = state[tab].map((item, idx) => {
-        if (idx === toggleIdx) {
-          const toggledItem = { ...item, soldOut: !item.soldOut }
-          return toggledItem
-        }
-        return item
-      })
-      return { ...state, [tab]: toggledMenu }
+      const removedMenu = state.menuList[tab].filter(
+        (_, idx) => idx !== removeIdx
+      )
+      return { ...state, menuList: { ...state.menuList, [tab]: removedMenu } }
     default:
       return { ...state }
   }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -41,7 +41,6 @@
 // globalState, ComponentState 변경이 요소 전체가 리렌더링으로 이어질 수 밖에 없는 까닭? state, props, useReducer
 
 // REFACTOR
-// TODO 커링 함수로 변경: 지연 실행
 // TODO const로 선언하면 블록 내에서 같은 변수명 재사용 불가 -> 클린 코드?
 // TODO reducer는 디폴트값으로 initialState받을 때, localStorage를 연결하는게 맞을까?
 // TODO 최대한 Flat하게 state를 변경하거나 immutable.js 사용하거나 deepcopy 수행하는 코드로 변경하기
@@ -84,6 +83,7 @@ const actionCreator = (type) => (payload) => {
 
 /**
  * actionCreators
+ * 휴먼 에러 방지 목적
  */
 const createInitAction = actionCreator(INIT_MENU);
 const createAddAction = actionCreator(ADD_MENU);
@@ -119,7 +119,6 @@ const createStore = (reducer) => {
 
   function getState() {
     return state;
-    return { ...state }; // TODO 차이?
   }
 
   // 클로저로 private state, private callbacks 구현해 정보 은닉
@@ -168,7 +167,7 @@ const getInitState = () => {
  * @param {Object} state
  * @param {Object} action
  * @description state를 복제한 객체에 action.type에 따라 상태 변경을 반영한 결과를 반환하는 함수
- * @toddo const로 선언하면 블록 내에서 같은 변수명 재사용 불가 -> 클린 코드?
+ * @todo const로 선언하면 블록 내에서 같은 변수명 재사용 불가 -> 클린 코드?
  * @todo reducer는 디폴트값으로 initialState받을 때, localStorage를 연결하는게 맞을까?
  * @todo 최대한 Flat하게 state를 변경하거나 immutable.js 사용하거나 deepcopy 수행하는 코드로 변경하기
  */

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -33,8 +33,23 @@
  * **********************************************************************
  **/
 
+// NOTION KEYWORD
+// 카테고리 명칭 상수화: 휴먼 에러 방지 - 실제 desert 사례
+// 커링 함수: 지연 실행
+// store 클로저로 state private으로 구현
+// state가 최대 2 layer까지만 권장되는 까닭? ... spread 연산자 vs deepcopy(immutable.js)
+// globalState, ComponentState 변경이 요소 전체가 리렌더링으로 이어질 수 밖에 없는 까닭? state, props, useReducer
+
+// REFACTOR
+// TODO 커링 함수로 변경: 지연 실행
+// TODO const로 선언하면 블록 내에서 같은 변수명 재사용 불가 -> 클린 코드?
+// TODO reducer는 디폴트값으로 initialState받을 때, localStorage를 연결하는게 맞을까?
+// TODO 최대한 Flat하게 state를 변경하거나 immutable.js 사용하거나 deepcopy 수행하는 코드로 변경하기
+// TODO 향후 추상화하려면 모든 이벤트를 최상위객체 .app에 위임
+// TODO updateTotal, updateTitle에서 DOM 직접조작 하지 않도록 렌더링 로직 분리하기(추상화 할 때 적용하기)
+
 /*
- * MENU_CATEGORIES: 카테고리 명칭 상수화(휴먼 에러 방지 - 실제 desert 사례)
+ * MENU_CATEGORIES: 카테고리 명칭
  */
 const ESPRESSO = "espresso"
 const FRAPPUCINO = "frappuccino"
@@ -43,7 +58,7 @@ const TEAVANA = "teavana"
 const DESSERT = "dessert"
 
 /*
- * ACTION_TYPES: 액션 타입 명칭 상수화(휴먼 에러 방지)
+ * ACTION_TYPES: 액션 타입 명칭
  */
 const INIT_MENU = "init-menu"
 const ADD_MENU = "add-menu"
@@ -257,8 +272,8 @@ const toggleMenu = (e) => {
 
 /*
  * setEventHandler: DOM 요소에 이벤트 핸들러 등록
+ * TODO 향후 추상화하려면 모든 이벤트를 최상위객체 .app에 위임
  **/
-// TODO 향후 추상화하려면 모든 이벤트를 최상위객체 .app에 위임
 const setEventHandler = () => {
   const nav = $("nav")
   const form = $("form")
@@ -292,8 +307,8 @@ const setEventHandler = () => {
 
 /*
  * 하단의 updateTotal, updateTitle은 DOM 요소에 직접 접근하여 DOM 요소를 조작하여 직접 렌더링 수행
+ * TODO updateTotal, updateTitle에서 DOM 직접조작 하지 않도록 렌더링 로직 분리하기(추상화 할 때 적용하기)
  **/
-// TODO updateTotal, updateTitle에서 DOM 직접조작 하지 않도록 렌더링 로직 분리하기
 const updateTotal = () => {
   const { menuList } = store.getState()
   const { tab } = componentState
@@ -353,8 +368,8 @@ const template = (menu) => {
 
 /*
  * render: 맨 처음이나 컴포넌트 상태 변화시 DOM 요소 조정 과정을 추상화한 함수
+ * TODO globalState, ComponentState 변경이 요소 전체가 리렌더링으로 이어지는 맥락 파악하기
  **/
-// TODO globalState, ComponentState 변경이 요소 전체가 리렌더링으로 이어지는 맥락 파악하기
 const render = () => {
   const { menuList } = store.getState()
   const { tab } = componentState

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -56,15 +56,6 @@ const BLENDED = "blended";
 const TEAVANA = "teavana";
 const DESSERT = "dessert";
 
-/**
- * ACTION_TYPES: 액션 타입 명칭
- */
-const INIT_MENU = "init-menu";
-const ADD_MENU = "add-menu";
-const UPDATE_MENU = "update-menu";
-const REMOVE_MENU = "remove-menu";
-const TOGGLE_MENU = "toggle-menu";
-
 const $ = (selector) => document.querySelector(selector);
 
 /**
@@ -75,13 +66,30 @@ let componentState = {
 };
 
 /**
+ * ACTION_TYPES: 액션 타입 명칭
+ */
+const INIT_MENU = "init-menu";
+const ADD_MENU = "add-menu";
+const UPDATE_MENU = "update-menu";
+const REMOVE_MENU = "remove-menu";
+const TOGGLE_MENU = "toggle-menu";
+
+/**
  * @function actionCreator
  * @description type과 payload를 받아 action 객체를 반환하는 함수
- * @todo 커링 함수로 변경: 지연 실행
  */
-const actionCreator = (type, payload) => {
+const actionCreator = (type) => (payload) => {
   return { type, payload };
 };
+
+/**
+ * actionCreators
+ */
+const createInitAction = actionCreator(INIT_MENU);
+const createAddAction = actionCreator(ADD_MENU);
+const createUpdateAction = actionCreator(UPDATE_MENU);
+const createRemoveAction = actionCreator(REMOVE_MENU);
+const createToggleAction = actionCreator(TOGGLE_MENU);
 
 /**
  * @function createStore
@@ -242,8 +250,7 @@ const addMenu = () => {
 
   if (!name) return;
 
-  store.dispatch(actionCreator(ADD_MENU, { name }));
-  // setState({ menu: [...menu, name] }) // setState 통해 메뉴 추가시 자동으로 DOM 요소 처리함
+  store.dispatch(createAddAction({ name }));
 
   input.value = "";
 };
@@ -261,14 +268,7 @@ const updateMenu = (e) => {
 
   if (newName === null) return;
 
-  store.dispatch(actionCreator(UPDATE_MENU, { updateIdx, newName }));
-  // setState 통해 메뉴 업데이트 시 자동으로 DOM 요소 처리함
-  // setState({
-  //   menu: menu.map((name, idx) => {
-  //     if (index === idx) return newName
-  //     return name
-  //   }),
-  // })
+  store.dispatch(createUpdateAction({ updateIdx, newName }));
 };
 
 /**
@@ -282,11 +282,7 @@ const removeMenu = (e) => {
 
   const removeIdx = Number(e.target.dataset.index);
 
-  store.dispatch(actionCreator(REMOVE_MENU, { removeIdx }));
-  // setState 통해 메뉴 삭제 시 자동으로 DOM 요소 처리함
-  // setState({
-  //   menu: menu.filter((_, idx) => index !== idx),
-  // })
+  store.dispatch(createRemoveAction({ removeIdx }));
 };
 
 /**
@@ -297,7 +293,7 @@ const removeMenu = (e) => {
 const toggleMenu = (e) => {
   const toggleIdx = Number(e.target.dataset.index);
 
-  store.dispatch(actionCreator(TOGGLE_MENU, { toggleIdx }));
+  store.dispatch(createToggleAction({ toggleIdx }));
 };
 
 /**


### PR DESCRIPTION
## 👨‍💻 v1 -> v2 리팩토링
### 🗒️ 핵심 변화
- ✅ (1) 전역 데이터 관리를 위해 단방향 데이터 흐름인 FLUX 패턴 도입
- ✅ (2) Redux 모방하여 전역 데이터 상태를 관리하고 업데이트하는 메서드 구현
- ✅ (3) 전역 상태로 관리할 데이터와 컴포넌트 내부에서 관리할 데이터 분리

## ✨ 리팩토링 배경
> 💡  Redux의 전역 상태 관리 흐름을 모방하면, 단방향 데이터 흐름인 FLUX 및 Redux 내부 동작 방식에 대한 이해를 높일 수 있을 것이라는 기대하에 리팩토링을 진행.

### 😅 v1: localStorage에 전역 상태를 저장하는 방식으로 전역 데이터 관리 수행

### 😆 v3: store에서만 state를 변경하고 view에서는 상태 변경 요청만 넣도록 역할 구분


## 🤔 추가로 고치고 싶은 부분
// NOTION KEYWORD
// 카테고리 명칭 상수화: 휴먼 에러 방지 - 실제 desert 사례
// 커링 함수: 지연 실행
// store 클로저로 state private으로 구현
// state가 최대 2 layer까지만 권장되는 까닭? ... spread 연산자 vs deepcopy(immutable.js)
// globalState, ComponentState 변경이 요소 전체가 리렌더링으로 이어질 수 밖에 없는 까닭? state, props, useReducer


// TODO 커링 함수로 변경: 지연 실행
// TODO const로 선언하면 블록 내에서 같은 변수명 재사용 불가 -> 클린 코드?
// TODO reducer는 디폴트값으로 initialState받을 때, localStorage를 연결하는게 맞을까?
// TODO 최대한 Flat하게 state를 변경하거나 immutable.js 사용하거나 deepcopy 수행하는 코드로 변경하기
// TODO updateTotal, updateTitle에서 DOM 직접조작 하지 않도록 렌더링 로직 분리하기(추상화 할 때 적용하기)